### PR TITLE
:sparkles: support skip/take arguments for findMany

### DIFF
--- a/__tests__/skip-take.test.ts
+++ b/__tests__/skip-take.test.ts
@@ -1,0 +1,100 @@
+// @ts-nocheck
+
+import createPrismaClient from '../src';
+
+const data = {
+  user: [
+    {
+      id: 1,
+      name: 'sadfsdf',
+      accountId: 1,
+    },
+  ],
+  account: [
+    {
+      id: 1,
+      name: 'B',
+    },
+    {
+      id: 2,
+      name: 'A',
+    },
+  ],
+};
+
+for (let i = 0; i < 10; i++) {
+  data.user.push({
+    id: i + 2,
+    name: `user ${i + 2}`,
+    accountId: 2,
+  });
+}
+
+test('findMany skip', async () => {
+  const client = await createPrismaClient(data);
+  const users = await client.user.findMany({
+    skip: 9,
+  });
+  expect(users).toEqual(data.user.slice(9));
+});
+
+test('findMany take', async () => {
+  const client = await createPrismaClient(data);
+  const users = await client.user.findMany({
+    take: 2,
+  });
+  expect(users).toEqual(data.user.slice(0, 2));
+});
+
+test('findMany skip/take', async () => {
+  const client = await createPrismaClient(data);
+  const users = await client.user.findMany({
+    skip: 9,
+    take: 1,
+  });
+  expect(users).toEqual(data.user.slice(9, 10));
+});
+
+test('findMany skip=0', async () => {
+  const client = await createPrismaClient(data);
+  const users = await client.user.findMany({
+    skip: 0,
+  });
+  expect(users).toEqual(data.user);
+});
+
+test('findMany take=0', async () => {
+  const client = await createPrismaClient(data);
+  const users = await client.user.findMany({
+    take: 0,
+  });
+  expect(users).toEqual([]);
+});
+
+test('findMany skip/take with where clause', async () => {
+  const client = await createPrismaClient(data);
+  const users = await client.user.findMany({
+    where: {
+      accountId: 2,
+    },
+    skip: 8,
+    take: 2,
+  });
+  expect(users).toEqual(data.user.slice(9, 11));
+});
+
+test('findMany skip/take on relation', async () => {
+  const client = await createPrismaClient(data);
+  const users = await client.account.findUnique({
+    where: {
+      id: 2,
+    },
+    include: {
+      users: {
+        skip: 8,
+        take: 2,
+      },
+    },
+  });
+  expect(users).toEqual({ ...data.account[1], users: data.user.slice(9, 11) });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,8 +129,8 @@ const createPrismaMock = <P>(
       }
       return 0
     }
-    
-  
+
+
 
     const nestedUpdate = (args, isCreating: boolean, item) => {
       let d = args.data
@@ -504,11 +504,12 @@ const createPrismaMock = <P>(
       }
       return items[0]
     }
+
     const findMany = args => {
-      const res = data[prop].filter(matchFnc(args?.where)).map(includes(args))
+      let res = data[prop].filter(matchFnc(args?.where)).map(includes(args))
       if (args?.distinct) {
         let values = {}
-        return res.filter(item => {
+        res = res.filter(item => {
           let shouldInclude = true
           args.distinct.forEach(key => {
             const vals = values[key] || []
@@ -526,11 +527,16 @@ const createPrismaMock = <P>(
         res.sort(sortFunc(args?.orderBy))
       }
       if (args?.select) {
-        return res.map(item => {
+        res = res.map(item => {
           const newItem = {}
-          Object.keys(args.select).forEach(key => newItem[key] = item[key])
+          Object.keys(args.select).forEach(key => (newItem[key] = item[key]))
           return newItem
         })
+      }
+      if (args?.skip !== undefined || args?.take !== undefined) {
+        const start = args?.skip !== undefined ? args?.skip : 0
+        const end = args?.take !== undefined ? start + args.take : undefined
+        res = res.slice(start, end)
       }
       return res
     }
@@ -639,7 +645,7 @@ const createPrismaMock = <P>(
         const schema = model.fields.find(field => {
           return field.name === key
         })
-        
+
         if (!schema?.relationName) {
           return
         }


### PR DESCRIPTION
Support arguments `skip` and `take` in `findMany` queries. According to the [Prisma docs](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#findmany):

> * `skip`: Specifies how many of the returned objects in the list should be skipped.
> * `take`: Specifies how many objects should be returned in the list