### PR TITLE
fix: ignore undefined values to retain official prisma behavior

### DIFF
--- a/__tests__/update.test.ts
+++ b/__tests__/update.test.ts
@@ -1,16 +1,14 @@
-
 // @ts-nocheck
 
 import createPrismaClient from "../src";
 
 describe("PrismaMock update", () => {
-
   const data = {
     user: [
-      { id: 1, name: 'Henk', clicks: 2 },
-      { id: 2, name: 'Piet', clicks: 5 },
-    ]
-  }
+      { id: 1, name: "Henk", clicks: 2 },
+      { id: 2, name: "Piet", clicks: 5 },
+    ],
+  };
 
   test("increment", async () => {
     const client = await createPrismaClient(data);
@@ -20,11 +18,11 @@ describe("PrismaMock update", () => {
           increment: 10,
         },
       },
-    })
-    const users = await client.user.findMany()
+    });
+    const users = await client.user.findMany();
     expect(users[0].clicks).toEqual(12);
     expect(users[1].clicks).toEqual(15);
-  })
+  });
 
   test("increment negative", async () => {
     const client = await createPrismaClient(data);
@@ -34,12 +32,12 @@ describe("PrismaMock update", () => {
           increment: -1,
         },
       },
-    })
-    const users = await client.user.findMany()
+    });
+    const users = await client.user.findMany();
     expect(users[0].clicks).toEqual(1);
     expect(users[1].clicks).toEqual(4);
-  })
-  
+  });
+
   test("increment where", async () => {
     const client = await createPrismaClient(data);
     await client.user.updateMany({
@@ -49,13 +47,13 @@ describe("PrismaMock update", () => {
         },
       },
       where: {
-        id: 1
-      }
-    })
-    const users = await client.user.findMany()
+        id: 1,
+      },
+    });
+    const users = await client.user.findMany();
     expect(users[0].clicks).toEqual(12);
     expect(users[1].clicks).toEqual(5);
-  })
+  });
 
   test("decrement", async () => {
     const client = await createPrismaClient(data);
@@ -65,11 +63,11 @@ describe("PrismaMock update", () => {
           decrement: 1,
         },
       },
-    })
-    const users = await client.user.findMany()
+    });
+    const users = await client.user.findMany();
     expect(users[0].clicks).toEqual(1);
     expect(users[1].clicks).toEqual(4);
-  })
+  });
 
   test("multiply", async () => {
     const client = await createPrismaClient(data);
@@ -79,11 +77,11 @@ describe("PrismaMock update", () => {
           multiply: 2,
         },
       },
-    })
-    const users = await client.user.findMany()
+    });
+    const users = await client.user.findMany();
     expect(users[0].clicks).toEqual(4);
     expect(users[1].clicks).toEqual(10);
-  })
+  });
 
   test("divide", async () => {
     const client = await createPrismaClient(data);
@@ -93,11 +91,11 @@ describe("PrismaMock update", () => {
           divide: 2,
         },
       },
-    })
-    const users = await client.user.findMany()
+    });
+    const users = await client.user.findMany();
     expect(users[0].clicks).toEqual(1);
     expect(users[1].clicks).toEqual(2.5);
-  })
+  });
 
   test("set", async () => {
     const client = await createPrismaClient(data);
@@ -107,10 +105,24 @@ describe("PrismaMock update", () => {
           set: 2,
         },
       },
-    })
-    const users = await client.user.findMany()
+    });
+    const users = await client.user.findMany();
     expect(users[0].clicks).toEqual(2);
     expect(users[1].clicks).toEqual(2);
-  })
+  });
 
-})
+  test("undefined values are unchanged", async () => {
+    const client = await createPrismaClient(data);
+    await client.user.update({
+      where: {
+        id: 1,
+      },
+      data: {
+        name: undefined,
+      },
+    });
+    const user = await client.user.findUnique({ where: { id: 1 } });
+    expect(user.name).toEqual("Henk");
+    expect(user.clicks).toEqual(2);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,11 @@ const createPrismaMock = <P>(
 
     const nestedUpdate = (args, isCreating: boolean, item) => {
       let d = args.data;
+      Object.entries(d).forEach(([key, value]) => {
+        if (typeof value === "undefined") {
+          delete d[key];
+        }
+      });
 
       // Get field schema for default values
       const model = datamodel.models.find((model) => {


### PR DESCRIPTION
When calling `update` and the `data` has  a key set to `undefined` the official prisma client will skip these values and leave them unchanged. This update adds that functionality to this package.