### PR TITLE
Feature use combined-unique index on connect

### DIFF
--- a/__tests__/__snapshots__/where.test.ts.snap
+++ b/__tests__/__snapshots__/where.test.ts.snap
@@ -32,11 +32,11 @@ exports[`PrismaClient where Case inrelevant date 1`] = `
 Array [
   Object {
     "authorId": null,
-    "created": 2020-01-31T23:00:00.000Z,
+    "created": 2020-01-31T15:00:00.000Z,
     "id": 1,
     "published": false,
     "title": "Piet",
-    "updated": 2020-01-31T23:00:00.000Z,
+    "updated": 2020-01-31T15:00:00.000Z,
   },
 ]
 `;

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -251,9 +251,42 @@ Array [
   },
 ]
 `)
-
   })
 
+  test("create connect (via unique)", async () => {
+    const client = await createPrismaClient({})
+    const user = await client.user.create({
+      data: {
+        role: "USER",
+        name: "Bob",
+        uniqueField: "user",
+        pets: {
+          create: {
+            name: "John",
+          },
+        },
+      },
+    })
+    const toy = await client.toy.create({
+      data: {
+        name: "Ball",
+        owner: {
+          connect: {
+            name_ownerId: {
+              name: "John",
+              ownerId: 1,
+            },
+          },
+        },
+      },
+    })
+
+    expect(toy).toEqual({
+      id: 1,
+      name: "Ball",
+      ownerId: 1,
+    })
+  })
 
   test("delete", async () => {
     const client = await createPrismaClient(data)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   sort        Int?
   posts       Post[]
   documents   Document[]
+  pets        Pet[]
 }
 
 model Stripe {
@@ -91,4 +92,21 @@ model Post {
   authorId  Int?
   updated   DateTime @updatedAt
   created   DateTime @default(now())
+}
+
+model Pet {
+  id      Int    @id @default(autoincrement())
+  name    String
+  owner   User   @relation(fields: [ownerId], references: [id])
+  ownerId Int
+  has     Toy[]
+
+  @@unique([name, ownerId])
+}
+
+model Toy {
+  id      Int    @id @default(autoincrement())
+  name    String
+  owner   Pet?   @relation(fields: [ownerId], references: [id])
+  ownerId Int
 }


### PR DESCRIPTION
Hi
I found issue and implement behavior.
## Problem
Throw error when create a record with connects via combined-unique index to already exists.

## Fix
Look-up record by unique index with combined-key after single key look-up failed.

## Tests
* [x] postgress
* [x] mock