### PR TITLE
Get Internal State of Client

### DIFF
--- a/__tests__/__snapshots__/where.test.ts.snap
+++ b/__tests__/__snapshots__/where.test.ts.snap
@@ -201,21 +201,6 @@ Array [
 ]
 `;
 
-exports[`PrismaClient where caseInsensitive false No mode OR 2`] = `
-Array [
-  Object {
-    "id": 1,
-    "name": "Piet",
-    "sort": null,
-  },
-  Object {
-    "id": 2,
-    "name": "Dirk",
-    "sort": null,
-  },
-]
-`;
-
 exports[`PrismaClient where caseInsensitive false No mode in (nested) 1`] = `
 Array [
   Object {

--- a/__tests__/internal-state.test.ts
+++ b/__tests__/internal-state.test.ts
@@ -1,0 +1,214 @@
+// @ts-nocheck
+
+import createPrismaClient from "./createPrismaClient";
+
+describe("PrismaClient $getInternalState", () => {
+  const data = {
+    user: [
+      {
+        name: "sadfsdf",
+        uniqueField: "user1",
+      },
+    ],
+    answers: [
+      {
+        id: 1,
+        title: "Answer",
+      },
+      {
+        id: 2,
+        title: "Answer",
+      },
+      {
+        id: 3,
+        title: "Answer",
+      },
+    ],
+    userAnswers: [],
+    element: [],
+  };
+
+  test("base", async () => {
+    const client = await createPrismaClient(data);
+
+    expect(client.$getInternalState()).toMatchInlineSnapshot(`
+Object {
+  "account": Array [],
+  "answers": Array [
+    Object {
+      "id": 1,
+      "title": "Answer",
+    },
+    Object {
+      "id": 2,
+      "title": "Answer",
+    },
+    Object {
+      "id": 3,
+      "title": "Answer",
+    },
+  ],
+  "document": Array [],
+  "element": Array [],
+  "pet": Array [],
+  "post": Array [],
+  "stripe": Array [],
+  "toy": Array [],
+  "transaction": Array [],
+  "user": Array [
+    Object {
+      "accountId": null,
+      "clicks": null,
+      "deleted": false,
+      "id": 1,
+      "name": "sadfsdf",
+      "role": "ADMIN",
+      "sort": null,
+      "uniqueField": "user1",
+    },
+  ],
+  "userAnswers": Array [],
+}
+`)
+  });
+
+  test("create", async () => {
+    const client = await createPrismaClient(data);
+    await client.userAnswers.create({
+      data: {
+        user: { connect: { id: 1 } },
+        answer: { connect: { id: 1 } },
+      },
+    });
+
+    expect(client.$getInternalState()).toMatchInlineSnapshot(`
+Object {
+  "account": Array [],
+  "answers": Array [
+    Object {
+      "id": 1,
+      "title": "Answer",
+    },
+    Object {
+      "id": 2,
+      "title": "Answer",
+    },
+    Object {
+      "id": 3,
+      "title": "Answer",
+    },
+  ],
+  "document": Array [],
+  "element": Array [],
+  "pet": Array [],
+  "post": Array [],
+  "stripe": Array [],
+  "toy": Array [],
+  "transaction": Array [],
+  "user": Array [
+    Object {
+      "accountId": null,
+      "clicks": null,
+      "deleted": false,
+      "id": 1,
+      "name": "sadfsdf",
+      "role": "ADMIN",
+      "sort": null,
+      "uniqueField": "user1",
+    },
+  ],
+  "userAnswers": Array [
+    Object {
+      "answerId": 1,
+      "userId": 1,
+      "value": null,
+    },
+  ],
+}
+`)
+  });
+
+  test("delete", async () => {
+    const client = await createPrismaClient(data);
+
+    await client.answers.deleteMany({})
+
+    expect(client.$getInternalState()).toMatchInlineSnapshot(`
+Object {
+  "account": Array [],
+  "answers": Array [],
+  "document": Array [],
+  "element": Array [],
+  "pet": Array [],
+  "post": Array [],
+  "stripe": Array [],
+  "toy": Array [],
+  "transaction": Array [],
+  "user": Array [
+    Object {
+      "accountId": null,
+      "clicks": null,
+      "deleted": false,
+      "id": 1,
+      "name": "sadfsdf",
+      "role": "ADMIN",
+      "sort": null,
+      "uniqueField": "user1",
+    },
+  ],
+  "userAnswers": Array [],
+}
+`)
+  });
+
+  test("updateMany", async () => {
+    const client = await createPrismaClient(data);
+
+    await client.userAnswers.updateMany({
+      data: {
+        answerId: 3,
+      },
+    });
+
+    expect(client.$getInternalState()).toMatchInlineSnapshot(`
+Object {
+  "account": Array [],
+  "answers": Array [
+    Object {
+      "id": 1,
+      "title": "Answer",
+    },
+    Object {
+      "id": 2,
+      "title": "Answer",
+    },
+    Object {
+      "id": 3,
+      "title": "Answer",
+    },
+  ],
+  "document": Array [],
+  "element": Array [],
+  "pet": Array [],
+  "post": Array [],
+  "stripe": Array [],
+  "toy": Array [],
+  "transaction": Array [],
+  "user": Array [
+    Object {
+      "accountId": null,
+      "clicks": null,
+      "deleted": false,
+      "id": 1,
+      "name": "sadfsdf",
+      "role": "ADMIN",
+      "sort": null,
+      "uniqueField": "user1",
+    },
+  ],
+  "userAnswers": Array [],
+}
+`)
+  });
+
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1100,6 +1100,8 @@ const createPrismaMock = <P>(
     })
   })
 
+  client['$getInternalState'] = () => data
+
   // @ts-ignore
   return client
 }


### PR DESCRIPTION
It is useful to check that the internal state of the mock client matches an expected snapshot. The `$getInternalState` method on the mock client returns the `data` object for this purpose. This does not result in any 'native' calls, such as `findMany` for each entity.

For example usage, check the included tests.