### PR TITLE
fix: respect Prisma's createMany/updateMany/deleteMany return type

### DIFF
--- a/__tests__/bulk-operations.test.ts
+++ b/__tests__/bulk-operations.test.ts
@@ -1,0 +1,64 @@
+import createPrismaClient from './createPrismaClient'
+
+describe("bulk-operations", () => {
+  const data = {
+    user: [
+      { id: 1, name: 'Henk', clicks: 2, uniqueField: '1' },
+      { id: 2, name: 'Piet', clicks: 5, uniqueField: '2' },
+    ]
+  }
+
+  test("updateMany", async () => {
+    const client = await createPrismaClient(data)
+    const { count } = await client.user.updateMany({
+      where: {
+        clicks: {
+          gt: 4
+        },
+      },
+      data: {
+        name: 'Bard'
+      }
+    })
+
+    const users = await client.user.findMany();
+    expect(users[0].name).toEqual('Henk');
+    expect(users[1].name).toEqual('Bard');
+    expect(count).toEqual(1)
+    
+    await client.$disconnect()
+  })
+
+  test("deleteMany", async () => {
+    const client = await createPrismaClient(data)
+    const { count } = await client.user.deleteMany({
+      where: {
+        clicks: {
+          gt: 4
+        },
+      },
+    })
+
+    const users = await client.user.findMany();
+    expect(users.length).toBe(1);
+    expect(count).toEqual(1)
+    
+    await client.$disconnect()
+  })
+
+  test("createMany", async () => {
+    const client = await createPrismaClient(data)
+    const { count } = await client.user.createMany({
+      data: [
+        { name: 'Plaf', clicks: 4, uniqueField: '4' },
+        { name: 'Klof', clicks: 2, uniqueField: '4' }
+      ]
+    })
+
+    const users = await client.user.findMany();
+    expect(users.length).toBe(4);
+    expect(count).toEqual(2)
+    
+    await client.$disconnect()
+  })
+})


### PR DESCRIPTION
The actual createMany/updateMany/deleteMany mock implementations didn't respect Prisma. All those operations should return a value of `type BatchOperation = { count: number }` where count is the number of affected records (cf. https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#return-type-7).

I modified existing implementations to make them return the appropriate type.