### PR TITLE
 Fix #36, doesn't return error code P2025 for not found errors

### DIFF
--- a/__tests__/errors.test.ts
+++ b/__tests__/errors.test.ts
@@ -49,6 +49,8 @@ Object {
     expect(e.message).toContain(
       "No Account found"
     )
+    expect(e.code).not.toBe(undefined)
+    expect(e.code).toBe("P2025")
   }
 })
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -115,6 +115,8 @@ describe("PrismaClient", () => {
         throw new Error("Test should not reach here")
       } catch (e) {
         expect(e.message).toContain("No Account found")
+        expect(e.code).not.toBe(undefined)
+        expect(e.code).toBe("P2025")
       }
     })
   })
@@ -137,6 +139,8 @@ describe("PrismaClient", () => {
         throw new Error("Test should not reach here")
       } catch (e) {
         expect(e.message).toContain("No Account found")
+        expect(e.code).not.toBe(undefined)
+        expect(e.code).toBe("P2025")
       }
     })
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ function IsFieldDefault(
 
 const throwKnownError = (message: string, cause?: string) => {
   const code = "P2025"
-  const clientVersion = "1.2.3"
+  const clientVersion = Prisma.prismaVersion.client
   // PrismaClientKnownRequestError prototype changed in version 4.7.0
   // from: constructor(message: string, code: string, clientVersion: string, meta?: any)
   // to: constructor(message: string, { code, clientVersion, meta, batchRequestIdx }: KnownErrorParams)

--- a/src/index.ts
+++ b/src/index.ts
@@ -866,12 +866,7 @@ const createPrismaMock = <P>(
     const findOrThrow = (args) => {
       const found = findOne(args)
       if (!found) {
-        throw new Prisma.PrismaClientKnownRequestError(
-          `No ${prop.slice(0, 1).toUpperCase()}${prop.slice(1)} found`,
-          "P2025",
-          // @ts-ignore
-          "1.2.3"
-        )
+        throwKnownError(`No ${prop.slice(0, 1).toUpperCase()}${prop.slice(1)} found`)
       }
       return found
     }


### PR DESCRIPTION
 Fix #36, doesn't return error code P2025 for not found errors. Also adds a small improvement to actually report the Prisma client version rather than mocking it.