### PR TITLE
fix: changes jest-mock-extended to dependency, not devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "cross-spawn": "^7.0.3",
     "env-cmd": "^10.1.0",
     "jest": "^27.3.1",
-    "jest-mock-extended": "^2.0.4",
     "prisma": "4.7.1",
     "ts-jest": "^27.0.7",
     "typescript": "^4.4.4",
@@ -31,5 +30,7 @@
   "peerDependencies": {
     "@prisma/client": "^3.5.0 || ^4.7.0 || ^5.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "jest-mock-extended": "^2.0.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",


### PR DESCRIPTION
prisma-mock does not run without jest-mock-extended, so putting it on dependencies allows me to use prisma-mock without having to declare jest-mock-extended on my package.json.