### PR TITLE
Propagate error in interactive transactions

### DIFF
--- a/__tests__/transaction-api.test.ts
+++ b/__tests__/transaction-api.test.ts
@@ -32,18 +32,25 @@ describe("prisma.$transaction", () => {
 
   test("interactive failed", async () => {
     const client = createPrismaClient(data);
+    let failed = false;
 
-    await client.$transaction(async tx => {
-      tx.user.create({ data: {
-        id: 3,
-        name: 'Anonymous',
-        accountId: 3
-      }})
-      throw new Error("failed")
-    })
+    try {
+      await client.$transaction(async tx => {
+        tx.user.create({ data: {
+          id: 3,
+          name: 'Anonymous',
+          accountId: 3
+        }})
+        throw new Error('failed')
+      })
+    } catch (error) {
+      failed = true;
+      expect(error.message).toEqual('failed');
+    }
 
     const allUsers = await client.user.findMany()
 
+    expect(failed).toBeTruthy();
     expect(allUsers).toHaveLength(2)
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,8 +185,9 @@ const createPrismaMock = <P>(
       try {
         return await actions(client)
       }
-      catch {
+      catch (error) {
         data = snapshot
+        throw error
       }
     }
   })
@@ -636,13 +637,7 @@ const createPrismaMock = <P>(
         return matchAnd(item, filter)
       }
       if (child === "NOT") {
-        if (Array.isArray(filter)) {
-          return !matchOr(item, filter)
-        }
-        item //?
-        filter //?
-        matchItems(item, filter) //?
-        return !matchItems(item, filter)
+        return !matchOr(item, filter)
       }
       if (filter == null || filter === undefined) {
         if (filter === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -637,7 +637,13 @@ const createPrismaMock = <P>(
         return matchAnd(item, filter)
       }
       if (child === "NOT") {
-        return !matchOr(item, filter)
+        if (Array.isArray(filter)) {
+          return !matchOr(item, filter)
+        }
+        item //?
+        filter //?
+        matchItems(item, filter) //?
+        return !matchItems(item, filter)
       }
       if (filter == null || filter === undefined) {
         if (filter === null) {


### PR DESCRIPTION
This fixes the issue for interactive transactions where errors were being silently caught. See https://github.com/demonsters/prisma-mock/issues/44