### PR TITLE
fix: allow delete against row even if whose related row is absent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1064,6 +1064,7 @@ const createPrismaMock = <P>(
               data: {
                 [joinfield.relationFromFields[0]]: null,
               },
+              skipForeignKeysChecks: true,
             })
           } else if (joinfield.relationOnDelete === "Cascade") {
             try {
@@ -1194,6 +1195,7 @@ const createPrismaMock = <P>(
         return e
       })
       if (!hasMatch) {
+        if (args.skipForeignKeysChecks) return;
         throwKnownError(
           "An operation failed because it depends on one or more records that were required but not found. Record to update not found.",
           { meta: { cause: "Record to update not found." } }


### PR DESCRIPTION
The unit test `Referential actions`-`onDelete`-`Cascade` fails while the test doesn't set up all rows of related tables with `Account`.

As I tested against real MySQL 8.0.28, it allows that situation on deletion.
So I thought the mock should do the same.