### PR TITLE
add client.$reset()

### DIFF
--- a/__tests__/reset.test.ts
+++ b/__tests__/reset.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+
+import { PrismaClient } from "@prisma/client"
+import createPrismaMock from "../src"
+
+describe("$reset", () => {
+  const defaultData = {
+    user: [{ id: 1, name: 'Henk', clicks: 2, uniqueField: 'user 1' }],
+  }
+
+  const client = createPrismaMock<PrismaClient>(defaultData);
+
+  test("$reset resets to initial state and data", async () => {
+    let user = await client.user.create({
+      data: {
+        name: "New user",
+        uniqueField: "new",
+      },
+    });
+    expect(user.id).toBe(2);
+
+    client.$reset();
+    const users = await client.user.findMany();
+    expect(users).toHaveLength(1);
+
+    user = await client.user.create({
+      data: {
+        name: "New user",
+        uniqueField: "new",
+      },
+    });
+    expect(user.id).toBe(2);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,11 @@ const throwKnownError = (message: string, { code = "P2025", meta }: { code?: str
   throw error
 }
 
+export type PrismaMock<P> = P & {
+  $getInternalState: () => any,
+  $reset: () => void,
+}
+
 export type MockPrismaOptions = {
   caseInsensitive?: boolean
   // datamodel?: Prisma.DMMF.Datamodel
@@ -78,8 +83,8 @@ const createPrismaMock = <P>(
   options: MockPrismaOptions = {
     caseInsensitive: false,
   }
-): P => {
-  const manyToManyData: { [relationName: string]: Array<{ [type: string]: Item }> } = {}
+): PrismaMock<P> => {
+  let manyToManyData: { [relationName: string]: Array<{ [type: string]: Item }> } = {}
 
   // let data = options.data || {}
   // const datamodel = options.datamodel || Prisma.dmmf.datamodel
@@ -1301,6 +1306,17 @@ const createPrismaMock = <P>(
   })
 
   client['$getInternalState'] = () => data
+
+  const original = {
+    data: deepCopy(data),
+    manyToMany: deepCopy(manyToManyData),
+  }
+
+  client['$reset'] = () => {
+    data = original.data
+    manyToManyData = original.manyToMany;
+    ResetDefaults()
+  };
 
   // @ts-ignore
   return client


### PR DESCRIPTION
This PR extend PrismaMock to have $reset() method that allows test clients to reset the mock state to its original.