### PR TITLE
Add "indexes" for faster lookup

### DIFF
--- a/__tests__/nested-one-to-many.test.ts
+++ b/__tests__/nested-one-to-many.test.ts
@@ -258,7 +258,7 @@ Object {
     })
     const user = await client.user.findUnique({
       where: {
-        accountId: 1
+        id: 2
       }
     })
     expect(user).toMatchInlineSnapshot(`
@@ -299,6 +299,122 @@ Object {
               id: 2,
             }
           }]
+        }
+      },
+      where: {
+        id: 1
+      },
+      include: {
+        users: true
+      }
+    })
+    expect(answer).toMatchInlineSnapshot(`
+Object {
+  "id": 1,
+  "name": null,
+  "sort": null,
+  "users": Array [
+    Object {
+      "accountId": 1,
+      "clicks": null,
+      "deleted": false,
+      "id": 2,
+      "name": null,
+      "role": "USER",
+      "sort": null,
+      "uniqueField": "user",
+    },
+  ],
+}
+`)
+  })
+
+  test('nested upsert create', async () => {
+    const client = await createPrismaClient({
+      account: [
+        { id: 1, }
+      ],
+      stripe: [{
+        customerId: "1",
+        accountId: 1,
+      }],
+      user: [
+        
+      ]
+    })
+    const answer = await client.account.update({
+      data: {
+        users: {
+          upsert: {
+            update: {
+              role: "USER"
+            },
+            create: {
+              id: 2,
+              role: "USER",
+              uniqueField: 'user'
+            },
+            where: {
+              id: 2,
+            }
+          }
+        }
+      },
+      where: {
+        id: 1
+      },
+      include: {
+        users: true
+      }
+    })
+    expect(answer).toMatchInlineSnapshot(`
+Object {
+  "id": 1,
+  "name": null,
+  "sort": null,
+  "users": Array [
+    Object {
+      "accountId": 1,
+      "clicks": null,
+      "deleted": false,
+      "id": 2,
+      "name": null,
+      "role": "USER",
+      "sort": null,
+      "uniqueField": "user",
+    },
+  ],
+}
+`)
+  })
+
+  test('nested upsert update', async () => {
+    const client = await createPrismaClient({
+      account: [
+        { id: 1, }
+      ],
+      stripe: [{
+        customerId: "1",
+        accountId: 1,
+      }],
+      user: [
+        { id: 2, role: "ADMIN", accountId: 1, uniqueField: 'user' }
+      ]
+    })
+    const answer = await client.account.update({
+      data: {
+        users: {
+          upsert: {
+            update: {
+              role: "USER"
+            },
+            create: {
+              uniqueField: "user"
+            },
+            where: {
+              id: 2,
+            }
+          }
         }
       },
       where: {
@@ -580,3 +696,5 @@ Array [
 ]
 `)
 })
+
+

--- a/__tests__/performance.test.ts
+++ b/__tests__/performance.test.ts
@@ -1,0 +1,65 @@
+import createPrismaClient from "./createPrismaClient"
+
+
+test("performance test", async () => {
+  const client = await createPrismaClient()
+  performance.mark("start-create")
+  for (let i = 0; i < 50; i++) {
+    await client.user.create({
+      data: {
+        uniqueField: `${i}`,
+        account: {
+          create: {
+            name: "client",
+            stripe: {
+              create: {
+                customerId: `${i}`
+              }
+            }
+          }
+        }
+      }
+    })
+  }
+  performance.mark("end-create")
+  performance.mark("start-find")
+  const dummyFunction = async () => {
+    const slides = await client.user.findMany({
+      where: {
+        account: {
+          stripe: {
+            customerId: "1",
+          }
+        }
+      },
+      orderBy: {
+        account: {
+          stripe: {
+            customerId: "asc"
+          }
+        }
+      },
+      include: {
+        account: {
+          include: {
+            stripe: true
+          }
+        }
+      }
+    })
+    return slides
+  }
+  await dummyFunction()
+
+  performance.mark("end-find")
+
+  const createDuration = performance.measure("create", "start-create", "end-create").duration
+  const findDuration = performance.measure("find", "start-find", "end-find").duration
+  
+  console.log(createDuration)
+  console.log(findDuration)
+  
+  expect(findDuration < 100).toBe(true)
+
+  // await expect(dummyFunction).toBeFasterThan(300)
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.8",
+  "version": "0.11.0-alpha.9",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.1",
+  "version": "0.11.0-alpha.2",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-beta.1",
+  "version": "0.11.0-alpha.1",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.3",
+  "version": "0.11.0-alpha.4",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.6",
+  "version": "0.11.0-alpha.7",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.5",
+  "version": "0.11.0-alpha.6",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.7",
+  "version": "0.11.0-alpha.8",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.2",
+  "version": "0.11.0-alpha.3",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.11.0-alpha.4",
+  "version": "0.11.0-alpha.5",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-mock",
-  "version": "0.10.0",
+  "version": "0.11.0-beta.1",
   "description": "Mock prisma for unit testing database",
   "main": "lib/index.js",
   "repository": "https://github.com/demonsters/prisma-mock",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1334,6 +1334,10 @@ const createPrismaMock = <P>(
       indexes.addIndexFieldIfNeeded(c, field)
     })
 
+    data[c].forEach((item) => {
+      indexes.updateItem(c, item)
+    })
+
     const objs = Delegate(c, model)
     Object.keys(objs).forEach((fncName) => {
       if (fncName.indexOf("_") === 0) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,10 +279,10 @@ const createPrismaMock = <P>(
     }
 
     const nestedUpdate = (args, isCreating: boolean, item: any) => {
-      let d = args.data
-      Object.entries(d).forEach(([key, value]) => {
+      let inputData = args.data
+      Object.entries(inputData).forEach(([key, value]) => {
         if (typeof value === "undefined") {
-          delete d[key]
+          delete inputData[key]
         }
       })
       // Get field schema for default values
@@ -291,11 +291,11 @@ const createPrismaMock = <P>(
       })
 
       model.fields.forEach((field) => {
-        if (d[field.name]) {
-          const c = d[field.name]
+        if (inputData[field.name]) {
+          let inputFieldData = inputData[field.name]
 
           if (isCreating && (field.isUnique || field.isId)) {
-            const existing = findOne({ where: { [field.name]: c } })
+            const existing = findOne({ where: { [field.name]: inputFieldData } })
             if (existing) {
               throwKnownError(
                 `Unique constraint failed on the fields: (\`${field.name}\`)`,
@@ -305,11 +305,11 @@ const createPrismaMock = <P>(
           }
 
           if (field.kind === "object") {
-            if (c.set) {
+            if (inputFieldData.set) {
               const {
                 [field.name]: { set },
                 ...rest
-              } = d
+              } = inputData
 
               const otherModel = datamodel.models.find((model) => {
                 return model.name === field.type
@@ -319,12 +319,12 @@ const createPrismaMock = <P>(
                   field.relationName === otherField.relationName
               )
               const delegate = Delegate(getCamelCase(field.type), otherModel)
-              const items = c.set.map(where => delegate.findUnique({
+              const items = inputFieldData.set.map(where => delegate.findUnique({
                 where
               })).filter(Boolean)
 
-              if (items.length !== c.set.length) {
-                throwKnownError(`An operation failed because it depends on one or more records that were required but not found. Expected ${c.set.length} records to be connected, found only ${items.length}.`)
+              if (items.length !== inputFieldData.set.length) {
+                throwKnownError(`An operation failed because it depends on one or more records that were required but not found. Expected ${inputFieldData.set.length} records to be connected, found only ${items.length}.`)
               }
 
               const idField = model?.fields.find((f) => f.isId)?.name
@@ -333,18 +333,18 @@ const createPrismaMock = <P>(
               items.forEach((createdItem) => {
                 a.push({
                   [field.type]: createdItem,
-                  [otherField.type]: item || d
+                  [otherField.type]: item || inputData
                 })
               })
               manyToManyData[field.relationName] = a
 
-              d = rest
+              inputData = rest
             }
-            if (c.connect) {
+            if (inputFieldData.connect) {
               const {
                 [field.name]: { connect },
                 ...rest
-              } = d
+              } = inputData
               const connections = connect instanceof Array ? connect : [connect]
               connections.forEach((connect, idx) => {
                 const keyToMatch = Object.keys(connect)[0]
@@ -396,13 +396,13 @@ const createPrismaMock = <P>(
                     connectionValue = matchingRow[keyToGet]
                   }
                   if (targetKey) {
-                    d = {
+                    inputData = {
                       ...rest,
                       [targetKey]: connectionValue,
                     }
                   }
                 } else {
-                  d = rest
+                  inputData = rest
                   const otherModel = datamodel.models.find((model) => {
                     return model.name === field.type
                   })
@@ -423,7 +423,7 @@ const createPrismaMock = <P>(
                       data: {
                         [getCamelCase(otherField.name)]: {
                           connect: {
-                            [otherTargetKey]: d[otherTargetKey],
+                            [otherTargetKey]: inputData[otherTargetKey],
                           },
                         },
                       }
@@ -434,20 +434,40 @@ const createPrismaMock = <P>(
                       [field.type]: delegate.findOne({
                         where: connect
                       }),
-                      [otherField.type]: item || d
+                      [otherField.type]: item || inputData
                     })
                   }
                 }
               })
             }
-            if (c.create || c.createMany) {
+
+            if (inputFieldData.upsert) {
+              const args = inputFieldData.upsert
+
+              const name = getCamelCase(field.type)
+              const delegate = Delegate(name, model)
+              const res = delegate.findOne(args)
+              if (res) {
+                delegate.update({
+                  where: args.where,
+                  data: args.update,
+                })
+              } else {
+                inputFieldData = {
+                  ...inputFieldData,
+                  create: inputFieldData.upsert.create,
+                }
+              }
+            }
+
+            if (inputFieldData.create || inputFieldData.createMany) {
 
               const otherModel = datamodel.models.find((model) => {
                 return model.name === field.type
               })
 
-              const { [field.name]: create, ...rest } = d
-              d = rest
+              const { [field.name]: _create, ...rest } = inputData
+              inputData = rest
               // @ts-ignore
               const name = getCamelCase(field.type)
               const delegate = Delegate(name, otherModel)
@@ -456,9 +476,9 @@ const createPrismaMock = <P>(
 
               if (field.relationFromFields.length > 0) {
                 const item = delegate.create({
-                  data: create.create,
+                  data: inputFieldData.create,
                 })
-                d = {
+                inputData = {
                   ...rest,
                   [field.relationFromFields[0]]:
                     item[field.relationToFields[0]],
@@ -473,7 +493,7 @@ const createPrismaMock = <P>(
                     [joinfield.name]: {
                       connect: joinfield.relationToFields.reduce(
                         (prev, cur, index) => {
-                          let val = d[cur]
+                          let val = inputData[cur]
                           if (!isCreating && !val) {
                             val = findOne(args)[cur]
                           }
@@ -489,21 +509,22 @@ const createPrismaMock = <P>(
                 }
 
                 let createdItems = []
-                if (c.createMany) {
+                if (inputFieldData.createMany) {
                   createdItems = delegate._createMany({
-                    ...c.createMany,
-                    data: c.createMany.data.map(map),
+                    ...inputFieldData.createMany,
+                    data: inputFieldData.createMany.data.map(map),
                   })
                 } else {
-                  if (Array.isArray(c.create)) {
+                  const data = inputFieldData.create
+                  if (Array.isArray(data)) {
                     createdItems = delegate._createMany({
-                      ...c.create,
-                      data: c.create.map(map),
+                      ...data,
+                      data: data.map(map),
                     })
                   } else {
                     createdItems = [delegate.create({
-                      ...create.create,
-                      data: map(create.create),
+                      ...data,
+                      data: map(data),
                     })]
                   }
                 }
@@ -515,7 +536,7 @@ const createPrismaMock = <P>(
                   createdItems.forEach((createdItem) => {
                     a.push({
                       [field.type]: createdItem,
-                      [joinfield.type]: item || d
+                      [joinfield.type]: item || inputData
                     })
                   })
                 }
@@ -525,18 +546,18 @@ const createPrismaMock = <P>(
 
             const name = getCamelCase(field.type)
             const delegate = Delegate(name, model)
-            if (c.updateMany) {
-              if (Array.isArray(c.updateMany)) {
-                c.updateMany.forEach((updateMany) => {
+            if (inputFieldData.updateMany) {
+              if (Array.isArray(inputFieldData.updateMany)) {
+                inputFieldData.updateMany.forEach((updateMany) => {
                   delegate.updateMany(updateMany)
                 })
               } else {
-                delegate.updateMany(c.updateMany)
+                delegate.updateMany(inputFieldData.updateMany)
               }
             }
-            if (c.update) {
-              if (Array.isArray(c.update)) {
-                c.update.forEach((update) => {
+            if (inputFieldData.update) {
+              if (Array.isArray(inputFieldData.update)) {
+                inputFieldData.update.forEach((update) => {
                   delegate.update(update)
                 })
               } else {
@@ -544,34 +565,34 @@ const createPrismaMock = <P>(
                 const where = getFieldRelationshipWhere(item, field, model)
                 if (where) {
                   delegate.update({
-                    data: c.update,
+                    data: inputFieldData.update,
                     where,
                   })
                 }
               }
             }
-            if (c.deleteMany) {
-              if (Array.isArray(c.deleteMany)) {
-                c.deleteMany.forEach((where) => {
+            if (inputFieldData.deleteMany) {
+              if (Array.isArray(inputFieldData.deleteMany)) {
+                inputFieldData.deleteMany.forEach((where) => {
                   delegate.deleteMany({ where })
                 })
               } else {
-                delegate.deleteMany({ where: c.deleteMany })
+                delegate.deleteMany({ where: inputFieldData.deleteMany })
               }
             }
-            if (c.delete) {
-              if (Array.isArray(c.delete)) {
-                c.delete.forEach((where) => {
+            if (inputFieldData.delete) {
+              if (Array.isArray(inputFieldData.delete)) {
+                inputFieldData.delete.forEach((where) => {
                   delegate.delete({ where })
                 })
               } else {
-                delegate.delete({ where: c.delete })
+                delegate.delete({ where: inputFieldData.delete })
               }
             }
-            if (c.disconnect) {
+            if (inputFieldData.disconnect) {
               if (field.relationFromFields.length > 0) {
-                d = {
-                  ...d,
+                inputData = {
+                  ...inputData,
                   [field.relationFromFields[0]]: null,
                 }
               } else {
@@ -587,73 +608,73 @@ const createPrismaMock = <P>(
                 })
               }
             }
-            const { [field.name]: _update, ...rest } = d
-            d = rest
+            const { [field.name]: _update, ...rest } = inputData
+            inputData = rest
           }
           if (field.kind === "scalar") {
-            if (c.increment) {
-              d = {
-                ...d,
-                [field.name]: item[field.name] + c.increment,
+            if (inputFieldData.increment) {
+              inputData = {
+                ...inputData,
+                [field.name]: item[field.name] + inputFieldData.increment,
               }
             }
-            if (c.decrement) {
-              d = {
-                ...d,
-                [field.name]: item[field.name] - c.decrement,
+            if (inputFieldData.decrement) {
+              inputData = {
+                ...inputData,
+                [field.name]: item[field.name] - inputFieldData.decrement,
               }
             }
-            if (c.multiply) {
-              d = {
-                ...d,
-                [field.name]: item[field.name] * c.multiply,
+            if (inputFieldData.multiply) {
+              inputData = {
+                ...inputData,
+                [field.name]: item[field.name] * inputFieldData.multiply,
               }
             }
-            if (c.divide) {
-              const newValue = item[field.name] / c.divide
-              d = {
-                ...d,
+            if (inputFieldData.divide) {
+              const newValue = item[field.name] / inputFieldData.divide
+              inputData = {
+                ...inputData,
                 [field.name]:
                   field.type === "Int" ? Math.floor(newValue) : newValue,
               }
             }
-            if (c.set) {
-              d = {
-                ...d,
-                [field.name]: c.set,
+            if (inputFieldData.set) {
+              inputData = {
+                ...inputData,
+                [field.name]: inputFieldData.set,
               }
             }
           }
         }
 
         if (
-          (isCreating || d[field.name] === null) &&
-          (d[field.name] === null || d[field.name] === undefined)
+          (isCreating || inputData[field.name] === null) &&
+          (inputData[field.name] === null || inputData[field.name] === undefined)
         ) {
           if (field.hasDefaultValue) {
             if (IsFieldDefault(field.default)) {
               const defaultValue = HandleDefault(prop, field, data)
               if (defaultValue) {
-                d = {
-                  ...d,
+                inputData = {
+                  ...inputData,
                   [field.name]: defaultValue,
                 }
               }
             } else {
-              d = {
-                ...d,
+              inputData = {
+                ...inputData,
                 [field.name]: field.default,
               }
             }
           } else if (field.isUpdatedAt) {
-            d = {
-              ...d,
+            inputData = {
+              ...inputData,
               [field.name]: new Date(),
             }
           } else {
             if (field.kind !== "object") {
-              d = {
-                ...d,
+              inputData = {
+                ...inputData,
                 [field.name]: null,
               }
             }
@@ -661,7 +682,7 @@ const createPrismaMock = <P>(
         }
         // return field.name === key
       })
-      return d
+      return inputData
     }
 
     const matchItem = (child: any, item: any, where: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1009,7 +1009,7 @@ const createPrismaMock = <P>(
             ...e,
             ...data,
           }
-          indexes.updateItem(prop, newItem)
+          indexes.updateItem(prop, newItem, e)
           return newItem
         }
         return e
@@ -1038,7 +1038,7 @@ const createPrismaMock = <P>(
         }
       }
       const item = findOne({ where, ...args })
-      indexes.updateItem(prop, item)
+      indexes.updateItem(prop, item, null)
       return item
     }
 
@@ -1228,7 +1228,7 @@ const createPrismaMock = <P>(
             ...e,
             ...data,
           }
-          indexes.updateItem(prop, updatedItem)
+          indexes.updateItem(prop, updatedItem, e)
           return updatedItem
         }
         return e
@@ -1335,7 +1335,7 @@ const createPrismaMock = <P>(
     })
 
     data[c].forEach((item) => {
-      indexes.updateItem(c, item)
+      indexes.updateItem(c, item, null)
     })
 
     const objs = Delegate(c, model)

--- a/src/indexes.test.ts
+++ b/src/indexes.test.ts
@@ -76,6 +76,12 @@ test("Index should be removed when set to null", () => {
     accountId: 1
   })
 
+  indexes.updateItem("User", {
+    id: 2,
+    name: "Piet",
+    accountId: 1
+  })
+
   const items1 = indexes.getIndexedItems("User", {
     accountId: 1
   })
@@ -87,6 +93,11 @@ Array [
     "id": 1,
     "name": "Alice",
   },
+  Object {
+    "accountId": 1,
+    "id": 2,
+    "name": "Piet",
+  },
 ]
 `)
 
@@ -94,12 +105,81 @@ Array [
     id: 1,
     name: "Alice",
     accountId: null
+  }, {
+    id: 1,
+    name: "Alice",
+    accountId: 1,
   })
 
   const items2 = indexes.getIndexedItems("User", {
     accountId: 1
   })
 
-  expect(items2).toMatchInlineSnapshot(`undefined`)
+  expect(items2).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": 1,
+    "id": 2,
+    "name": "Piet",
+  },
+]
+`)
+
+})
+
+test("Should add multiple items", () => {
+
+  const indexes = createIndexes()
+
+  indexes.addIndexFieldIfNeeded("User", {
+    name: "id",
+    isId: true
+  })
+  indexes.addIndexFieldIfNeeded("User", {
+    name: "account",
+    relationFromFields: ["accountId"]
+  })
+
+  indexes.updateItem("User", {
+    id: 1,
+    name: "Alice",
+    accountId: 1
+  })
+
+  indexes.updateItem("User", {
+    id: 2,
+    name: "Alice 2",
+    accountId: 1
+  })
+
+  indexes.updateItem("User", {
+    id: 3,
+    name: "Alice 3",
+    accountId: 1
+  })
+
+  const items = indexes.getIndexedItems("User", {
+    accountId: 1
+  })
+
+  expect(items).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": 1,
+    "id": 1,
+    "name": "Alice",
+  },
+  Object {
+    "accountId": 1,
+    "id": 2,
+    "name": "Alice 2",
+  },
+  Object {
+    "accountId": 1,
+    "id": 3,
+    "name": "Alice 3",
+  },
+]
+`)
 
 })

--- a/src/indexes.test.ts
+++ b/src/indexes.test.ts
@@ -56,3 +56,50 @@ Array [
 `)
 
 })
+
+test("Index should be removed when set to null", () => {
+
+  const indexes = createIndexes()
+
+  indexes.addIndexFieldIfNeeded("User", {
+    name: "id",
+    isId: true
+  })
+  indexes.addIndexFieldIfNeeded("User", {
+    name: "account",
+    relationFromFields: ["accountId"]
+  })
+
+  indexes.updateItem("User", {
+    id: 1,
+    name: "Alice",
+    accountId: 1
+  })
+
+  const items1 = indexes.getIndexedItems("User", {
+    accountId: 1
+  })
+
+  expect(items1).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": 1,
+    "id": 1,
+    "name": "Alice",
+  },
+]
+`)
+
+  indexes.updateItem("User", {
+    id: 1,
+    name: "Alice",
+    accountId: null
+  })
+
+  const items2 = indexes.getIndexedItems("User", {
+    accountId: 1
+  })
+
+  expect(items2).toMatchInlineSnapshot(`undefined`)
+
+})

--- a/src/indexes.test.ts
+++ b/src/indexes.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+
+import createIndexes from "./indexes"
+
+
+test("createIndexes", () => {
+  const indexes = createIndexes()
+
+  indexes.addIndexFieldIfNeeded("User", {
+    name: "id",
+    isId: true
+  })
+  indexes.addIndexFieldIfNeeded("User", {
+    name: "account",
+    relationFromFields: ["accountId"]
+  })
+
+  indexes.updateItem("User", {
+    id: 1,
+    name: "Alice",
+    accountId: 1
+  })
+
+  const items1 = indexes.getIndexedItems("User", {
+    accountId: 1
+  })
+
+  expect(items1).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": 1,
+    "id": 1,
+    "name": "Alice",
+  },
+]
+`)
+
+  indexes.updateItem("User", {
+    id: 1,
+    name: "Alice 2",
+    accountId: 1
+  })
+
+  const items2 = indexes.getIndexedItems("User", {
+    accountId: 1
+  })
+
+  expect(items2).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": 1,
+    "id": 1,
+    "name": "Alice 2",
+  },
+]
+`)
+
+})

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -1,0 +1,117 @@
+import { Prisma } from "@prisma/client"
+
+
+export default function createIndexes() {
+
+  let items: Record<string, Record<string, Record<string, any[]>>> = {}
+  let indexedFieldNames: Record<string, string[]> = {}
+  let fields: Record<string, Record<string, Prisma.DMMF.Field>> = {}
+  let idFieldNames: Record<string, string[]> = {}
+
+  const addIndexFieldIfNeeded = (tableName: string, field: Prisma.DMMF.Field) => {
+    if (!indexedFieldNames[tableName]) {
+      indexedFieldNames[tableName] = []
+    }
+    if (!fields[tableName]) {
+      fields[tableName] = {}
+    }
+    if (!idFieldNames[tableName]) {
+      idFieldNames[tableName] = []
+    }
+    let thisFields = fields[tableName]
+    let thisFieldNames = indexedFieldNames[tableName]
+    let thisIdFieldNames = idFieldNames[tableName]
+    if (thisFieldNames.includes(field.name)) return
+    if (field.isId || field.isUnique) {
+      thisFieldNames.push(field.name)
+    }
+    if (field.isId) {
+      thisIdFieldNames.push(field.name)
+    }
+    if (!!field.relationFromFields?.length) {
+      const fieldName = field.relationFromFields[0]
+      thisFieldNames.push(fieldName)
+    }
+    thisFields[field.name] = field
+  }
+
+  const getIndexedItems = (tableName: string, where: any) => {
+    for (const field in where) {
+      if (field === "AND") {
+        const subWhere = where.AND
+        if (Array.isArray(subWhere)) {
+          for (const subWhereItem of subWhere) {
+            const items = getIndexedItems(tableName, subWhereItem)
+            if (items) {
+              return items
+            }
+          }
+        }
+      }
+      if (indexedFieldNames[tableName]) {
+        if (indexedFieldNames[tableName].includes(field)) {
+          return items[tableName]?.[field]?.[where[field]]
+        }
+      }
+    }
+  }
+
+  const updateItem = (tableName: string, item: any) => {
+    if (!items[tableName]) {
+      items[tableName] = {}
+    }
+    if (!indexedFieldNames[tableName]) {
+      throw new Error(`No indexed fields for table ${tableName}`)
+    }
+    for (const fieldName of indexedFieldNames[tableName]) {
+      if (!items[tableName][fieldName]) {
+        items[tableName][fieldName] = {}
+      }
+      if (!items[tableName][fieldName][item[fieldName]]) {
+        items[tableName][fieldName][item[fieldName]] = [item]
+      } else {
+        const field = fields[tableName][fieldName]
+        if (field && (field.isId || field.isUnique)) {
+          items[tableName][fieldName][item[fieldName]] = [item]
+        } else {
+          const array = items[tableName][fieldName][item[fieldName]]
+          if (array.length === 0) {
+            array.push(item)
+          } else {
+            const thisIdFieldNames = idFieldNames[tableName] || []
+            let hasFound = false
+            for (let i = 0; i < array.length; i++) {
+              const oldItem = array[i]
+              for (const thisIdFieldName of thisIdFieldNames) {
+                if (item[thisIdFieldName] === oldItem[thisIdFieldName]) {
+                  hasFound = true
+                  array[i] = item
+                  return
+                }
+              }
+            }
+            if (!hasFound) {
+              array.push(item)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const deleteItemByField = (tableName: string, field: Prisma.DMMF.Field, item: any) => {
+    if (indexedFieldNames[tableName]) {
+      if (indexedFieldNames[tableName].includes(field.name)) {
+        delete items[tableName]?.[field.name]?.[item[field.name]]
+      }
+    }
+  }
+
+  return {
+    addIndexFieldIfNeeded,
+    getIndexedItems,
+    updateItem,
+    deleteItemByField
+  }
+
+}

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -3,24 +3,24 @@ import { Prisma } from "@prisma/client"
 
 export default function createIndexes() {
 
-  let items: Record<string, Record<string, Map<any, any[]>>> = {}
-  let indexedFieldNames: Record<string, string[]> = {}
-  let fields: Record<string, Record<string, Prisma.DMMF.Field>> = {}
-  let idFieldNames: Record<string, string[]> = {}
+  let items: Map<string, Map<string, Map<string, any[]>>> = new Map()
+  let indexedFieldNames: Map<string, string[]> = new Map()
+  let fields: Map<string, Map<string, Prisma.DMMF.Field>> = new Map()
+  let idFieldNames: Map<string, string[]> = new Map()
 
   const addIndexFieldIfNeeded = (tableName: string, field: Prisma.DMMF.Field) => {
-    if (!indexedFieldNames[tableName]) {
-      indexedFieldNames[tableName] = []
+    if (!indexedFieldNames.has(tableName)) {
+      indexedFieldNames.set(tableName, [])
     }
-    if (!fields[tableName]) {
-      fields[tableName] = {}
+    if (!fields.has(tableName)) {
+      fields.set(tableName, new Map())
     }
-    if (!idFieldNames[tableName]) {
-      idFieldNames[tableName] = []
+    if (!idFieldNames.has(tableName)) {
+      idFieldNames.set(tableName, [])
     }
-    let thisFields = fields[tableName]
-    let thisFieldNames = indexedFieldNames[tableName]
-    let thisIdFieldNames = idFieldNames[tableName]
+    let thisFields = fields.get(tableName)
+    let thisFieldNames = indexedFieldNames.get(tableName)
+    let thisIdFieldNames = idFieldNames.get(tableName)
     if (thisFieldNames.includes(field.name)) return
     if (field.isId || field.isUnique) {
       thisFieldNames.push(field.name)
@@ -32,7 +32,7 @@ export default function createIndexes() {
       const fieldName = field.relationFromFields[0]
       thisFieldNames.push(fieldName)
     }
-    thisFields[field.name] = field
+    thisFields.set(field.name, field)
   }
 
   const getIndexedItems = (tableName: string, where: any) => {
@@ -48,37 +48,43 @@ export default function createIndexes() {
           }
         }
       }
-      if (indexedFieldNames[tableName]) {
-        if (indexedFieldNames[tableName].includes(field)) {
-          return items[tableName]?.[field]?.get(where[field])
+      if (indexedFieldNames.has(tableName)) {
+        if (indexedFieldNames.get(tableName).includes(field)) {
+          return items.get(tableName)?.get(field)?.get(where[field])
         }
       }
     }
   }
 
   const updateItem = (tableName: string, item: any) => {
-    if (!items[tableName]) {
-      items[tableName] = {}
+    if (!items.has(tableName)) {
+      items.set(tableName, new Map())
     }
-    if (!indexedFieldNames[tableName]) {
+    if (!indexedFieldNames.has(tableName)) {
       throw new Error(`No indexed fields for table ${tableName}`)
     }
-    for (const fieldName of indexedFieldNames[tableName]) {
-      if (!items[tableName][fieldName]) {
-        items[tableName][fieldName] = new Map()
+    const tableItems = items.get(tableName)
+    for (const fieldName of indexedFieldNames.get(tableName)) {
+      if (!tableItems.has(fieldName)) {
+        tableItems.set(fieldName, new Map())
       }
-      if (!items[tableName][fieldName].has(item[fieldName])) {
-        items[tableName][fieldName].set(item[fieldName], [item])
+      if (!item[fieldName]) {
+        tableItems.delete(fieldName)
+        continue
+      }
+      const thisItems = tableItems.get(fieldName)
+      if (!thisItems.has(item[fieldName])) {
+        thisItems.set(item[fieldName], [item])
       } else {
-        const field = fields[tableName][fieldName]
+        const field = fields.get(tableName).get(fieldName)
         if (field && (field.isId || field.isUnique)) {
-          items[tableName][fieldName].set(item[fieldName], [item])
+          thisItems.set(item[fieldName], [item])
         } else {
-          const array = items[tableName][fieldName].get(item[fieldName])
+          const array = thisItems.get(item[fieldName])
           if (array.length === 0) {
             array.push(item)
           } else {
-            const thisIdFieldNames = idFieldNames[tableName] || []
+            const thisIdFieldNames = idFieldNames.get(tableName) || []
             let hasFound = false
             for (let i = 0; i < array.length; i++) {
               const oldItem = array[i]
@@ -100,9 +106,9 @@ export default function createIndexes() {
   }
 
   const deleteItemByField = (tableName: string, field: Prisma.DMMF.Field, item: any) => {
-    if (indexedFieldNames[tableName]) {
-      if (indexedFieldNames[tableName].includes(field.name)) {
-        items[tableName]?.[field.name]?.delete(item[field.name])
+    if (indexedFieldNames.has(tableName)) {
+      if (indexedFieldNames.get(tableName).includes(field.name)) {
+        items.get(tableName)?.get(field.name)?.delete(item[field.name])
       }
     }
   }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -86,7 +86,7 @@ export default function createIndexes() {
                 if (item[thisIdFieldName] === oldItem[thisIdFieldName]) {
                   hasFound = true
                   array[i] = item
-                  return
+                  continue
                 }
               }
             }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -3,24 +3,24 @@ import { Prisma } from "@prisma/client"
 
 export default function createIndexes() {
 
-  let items: Map<string, Map<string, Map<string, any[]>>> = new Map()
-  let indexedFieldNames: Map<string, string[]> = new Map()
-  let fields: Map<string, Map<string, Prisma.DMMF.Field>> = new Map()
-  let idFieldNames: Map<string, string[]> = new Map()
+  let items: Record<string, Record<string, Map<any, any[]>>> = {}
+  let indexedFieldNames: Record<string, string[]> = {}
+  let fields: Record<string, Record<string, Prisma.DMMF.Field>> = {}
+  let idFieldNames: Record<string, string[]> = {}
 
   const addIndexFieldIfNeeded = (tableName: string, field: Prisma.DMMF.Field) => {
-    if (!indexedFieldNames.has(tableName)) {
-      indexedFieldNames.set(tableName, [])
+    if (!indexedFieldNames[tableName]) {
+      indexedFieldNames[tableName] = []
     }
-    if (!fields.has(tableName)) {
-      fields.set(tableName, new Map())
+    if (!fields[tableName]) {
+      fields[tableName] = {}
     }
-    if (!idFieldNames.has(tableName)) {
-      idFieldNames.set(tableName, [])
+    if (!idFieldNames[tableName]) {
+      idFieldNames[tableName] = []
     }
-    let thisFields = fields.get(tableName)
-    let thisFieldNames = indexedFieldNames.get(tableName)
-    let thisIdFieldNames = idFieldNames.get(tableName)
+    let thisFields = fields[tableName]
+    let thisFieldNames = indexedFieldNames[tableName]
+    let thisIdFieldNames = idFieldNames[tableName]
     if (thisFieldNames.includes(field.name)) return
     if (field.isId || field.isUnique) {
       thisFieldNames.push(field.name)
@@ -32,7 +32,7 @@ export default function createIndexes() {
       const fieldName = field.relationFromFields[0]
       thisFieldNames.push(fieldName)
     }
-    thisFields.set(field.name, field)
+    thisFields[field.name] = field
   }
 
   const getIndexedItems = (tableName: string, where: any) => {
@@ -48,43 +48,41 @@ export default function createIndexes() {
           }
         }
       }
-      if (indexedFieldNames.has(tableName)) {
-        if (indexedFieldNames.get(tableName).includes(field)) {
-          return items.get(tableName)?.get(field)?.get(where[field])
+      if (indexedFieldNames[tableName]) {
+        if (indexedFieldNames[tableName].includes(field)) {
+          return items[tableName]?.[field]?.get(where[field])
         }
       }
     }
   }
 
   const updateItem = (tableName: string, item: any) => {
-    if (!items.has(tableName)) {
-      items.set(tableName, new Map())
+    if (!items[tableName]) {
+      items[tableName] = {}
     }
-    if (!indexedFieldNames.has(tableName)) {
+    if (!indexedFieldNames[tableName]) {
       throw new Error(`No indexed fields for table ${tableName}`)
     }
-    const tableItems = items.get(tableName)
-    for (const fieldName of indexedFieldNames.get(tableName)) {
-      if (!tableItems.has(fieldName)) {
-        tableItems.set(fieldName, new Map())
+    for (const fieldName of indexedFieldNames[tableName]) {
+      if (!items[tableName][fieldName]) {
+        items[tableName][fieldName] = new Map()
       }
       if (!item[fieldName]) {
-        tableItems.delete(fieldName)
-        continue
+          delete items[tableName][fieldName]
+          continue
       }
-      const thisItems = tableItems.get(fieldName)
-      if (!thisItems.has(item[fieldName])) {
-        thisItems.set(item[fieldName], [item])
+      if (!items[tableName][fieldName].has(item[fieldName])) {
+        items[tableName][fieldName].set(item[fieldName], [item])
       } else {
-        const field = fields.get(tableName).get(fieldName)
+        const field = fields[tableName][fieldName]
         if (field && (field.isId || field.isUnique)) {
-          thisItems.set(item[fieldName], [item])
+          items[tableName][fieldName].set(item[fieldName], [item])
         } else {
-          const array = thisItems.get(item[fieldName])
+          const array = items[tableName][fieldName].get(item[fieldName])
           if (array.length === 0) {
             array.push(item)
           } else {
-            const thisIdFieldNames = idFieldNames.get(tableName) || []
+            const thisIdFieldNames = idFieldNames[tableName] || []
             let hasFound = false
             for (let i = 0; i < array.length; i++) {
               const oldItem = array[i]
@@ -106,9 +104,9 @@ export default function createIndexes() {
   }
 
   const deleteItemByField = (tableName: string, field: Prisma.DMMF.Field, item: any) => {
-    if (indexedFieldNames.has(tableName)) {
-      if (indexedFieldNames.get(tableName).includes(field.name)) {
-        items.get(tableName)?.get(field.name)?.delete(item[field.name])
+    if (indexedFieldNames[tableName]) {
+      if (indexedFieldNames[tableName].includes(field.name)) {
+        items[tableName]?.[field.name]?.delete(item[field.name])
       }
     }
   }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -56,7 +56,7 @@ export default function createIndexes() {
     }
   }
 
-  const updateItem = (tableName: string, item: any) => {
+  const updateItem = (tableName: string, item: any, oldItem: any | null) => {
     if (!items[tableName]) {
       items[tableName] = {}
     }
@@ -68,7 +68,21 @@ export default function createIndexes() {
         items[tableName][fieldName] = new Map()
       }
       if (!item[fieldName]) {
-          delete items[tableName][fieldName]
+          if (oldItem && oldItem[fieldName]) {
+            const array = items[tableName][fieldName].get(oldItem[fieldName])
+            if (array) {
+              for (let i = 0; i < array.length; i++) {
+                const oldItem = array[i]
+                for (const thisIdFieldName of idFieldNames[tableName]) {
+                  if (item[thisIdFieldName] === oldItem[thisIdFieldName]) {
+                    array.splice(i, 1)
+                    i--
+                    continue
+                  }
+                }
+              }
+            }
+          }
           continue
       }
       if (!items[tableName][fieldName].has(item[fieldName])) {

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -3,24 +3,24 @@ import { Prisma } from "@prisma/client"
 
 export default function createIndexes() {
 
-  let items: Record<string, Record<string, Record<string, any[]>>> = {}
-  let indexedFieldNames: Record<string, string[]> = {}
-  let fields: Record<string, Record<string, Prisma.DMMF.Field>> = {}
-  let idFieldNames: Record<string, string[]> = {}
+  let items: Map<string, Map<string, Map<string, any[]>>> = new Map()
+  let indexedFieldNames: Map<string, string[]> = new Map()
+  let fields: Map<string, Map<string, Prisma.DMMF.Field>> = new Map()
+  let idFieldNames: Map<string, string[]> = new Map()
 
   const addIndexFieldIfNeeded = (tableName: string, field: Prisma.DMMF.Field) => {
-    if (!indexedFieldNames[tableName]) {
-      indexedFieldNames[tableName] = []
+    if (!indexedFieldNames.has(tableName)) {
+      indexedFieldNames.set(tableName, [])
     }
-    if (!fields[tableName]) {
-      fields[tableName] = {}
+    if (!fields.has(tableName)) {
+      fields.set(tableName, new Map())
     }
-    if (!idFieldNames[tableName]) {
-      idFieldNames[tableName] = []
+    if (!idFieldNames.has(tableName)) {
+      idFieldNames.set(tableName, [])
     }
-    let thisFields = fields[tableName]
-    let thisFieldNames = indexedFieldNames[tableName]
-    let thisIdFieldNames = idFieldNames[tableName]
+    let thisFields = fields.get(tableName)
+    let thisFieldNames = indexedFieldNames.get(tableName)
+    let thisIdFieldNames = idFieldNames.get(tableName)
     if (thisFieldNames.includes(field.name)) return
     if (field.isId || field.isUnique) {
       thisFieldNames.push(field.name)
@@ -32,7 +32,7 @@ export default function createIndexes() {
       const fieldName = field.relationFromFields[0]
       thisFieldNames.push(fieldName)
     }
-    thisFields[field.name] = field
+    thisFields.set(field.name, field)
   }
 
   const getIndexedItems = (tableName: string, where: any) => {
@@ -48,37 +48,39 @@ export default function createIndexes() {
           }
         }
       }
-      if (indexedFieldNames[tableName]) {
-        if (indexedFieldNames[tableName].includes(field)) {
-          return items[tableName]?.[field]?.[where[field]]
+      if (indexedFieldNames.has(tableName)) {
+        if (indexedFieldNames.get(tableName).includes(field)) {
+          return items.get(tableName)?.get(field)?.get(where[field])
         }
       }
     }
   }
 
   const updateItem = (tableName: string, item: any) => {
-    if (!items[tableName]) {
-      items[tableName] = {}
+    if (!items.has(tableName)) {
+      items.set(tableName, new Map())
     }
-    if (!indexedFieldNames[tableName]) {
+    if (!indexedFieldNames.has(tableName)) {
       throw new Error(`No indexed fields for table ${tableName}`)
     }
-    for (const fieldName of indexedFieldNames[tableName]) {
-      if (!items[tableName][fieldName]) {
-        items[tableName][fieldName] = {}
+    const tableItems = items.get(tableName)
+    for (const fieldName of indexedFieldNames.get(tableName)) {
+      if (!tableItems.has(fieldName)) {
+        tableItems.set(fieldName, new Map())
       }
-      if (!items[tableName][fieldName][item[fieldName]]) {
-        items[tableName][fieldName][item[fieldName]] = [item]
+      const thisItems = tableItems.get(fieldName)
+      if (!thisItems.has(item[fieldName])) {
+        thisItems.set(item[fieldName], [item])
       } else {
-        const field = fields[tableName][fieldName]
+        const field = fields.get(tableName).get(fieldName)
         if (field && (field.isId || field.isUnique)) {
-          items[tableName][fieldName][item[fieldName]] = [item]
+          thisItems.set(item[fieldName], [item])
         } else {
-          const array = items[tableName][fieldName][item[fieldName]]
+          const array = thisItems.get(item[fieldName])
           if (array.length === 0) {
             array.push(item)
           } else {
-            const thisIdFieldNames = idFieldNames[tableName] || []
+            const thisIdFieldNames = idFieldNames.get(tableName) || []
             let hasFound = false
             for (let i = 0; i < array.length; i++) {
               const oldItem = array[i]
@@ -100,9 +102,9 @@ export default function createIndexes() {
   }
 
   const deleteItemByField = (tableName: string, field: Prisma.DMMF.Field, item: any) => {
-    if (indexedFieldNames[tableName]) {
-      if (indexedFieldNames[tableName].includes(field.name)) {
-        delete items[tableName]?.[field.name]?.[item[field.name]]
+    if (indexedFieldNames.has(tableName)) {
+      if (indexedFieldNames.get(tableName).includes(field.name)) {
+        items.get(tableName)?.get(field.name)?.delete(item[field.name])
       }
     }
   }

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -3,24 +3,24 @@ import { Prisma } from "@prisma/client"
 
 export default function createIndexes() {
 
-  let items: Map<string, Map<string, Map<string, any[]>>> = new Map()
-  let indexedFieldNames: Map<string, string[]> = new Map()
-  let fields: Map<string, Map<string, Prisma.DMMF.Field>> = new Map()
-  let idFieldNames: Map<string, string[]> = new Map()
+  let items: Record<string, Record<string, Map<any, any[]>>> = {}
+  let indexedFieldNames: Record<string, string[]> = {}
+  let fields: Record<string, Record<string, Prisma.DMMF.Field>> = {}
+  let idFieldNames: Record<string, string[]> = {}
 
   const addIndexFieldIfNeeded = (tableName: string, field: Prisma.DMMF.Field) => {
-    if (!indexedFieldNames.has(tableName)) {
-      indexedFieldNames.set(tableName, [])
+    if (!indexedFieldNames[tableName]) {
+      indexedFieldNames[tableName] = []
     }
-    if (!fields.has(tableName)) {
-      fields.set(tableName, new Map())
+    if (!fields[tableName]) {
+      fields[tableName] = {}
     }
-    if (!idFieldNames.has(tableName)) {
-      idFieldNames.set(tableName, [])
+    if (!idFieldNames[tableName]) {
+      idFieldNames[tableName] = []
     }
-    let thisFields = fields.get(tableName)
-    let thisFieldNames = indexedFieldNames.get(tableName)
-    let thisIdFieldNames = idFieldNames.get(tableName)
+    let thisFields = fields[tableName]
+    let thisFieldNames = indexedFieldNames[tableName]
+    let thisIdFieldNames = idFieldNames[tableName]
     if (thisFieldNames.includes(field.name)) return
     if (field.isId || field.isUnique) {
       thisFieldNames.push(field.name)
@@ -32,7 +32,7 @@ export default function createIndexes() {
       const fieldName = field.relationFromFields[0]
       thisFieldNames.push(fieldName)
     }
-    thisFields.set(field.name, field)
+    thisFields[field.name] = field
   }
 
   const getIndexedItems = (tableName: string, where: any) => {
@@ -48,39 +48,37 @@ export default function createIndexes() {
           }
         }
       }
-      if (indexedFieldNames.has(tableName)) {
-        if (indexedFieldNames.get(tableName).includes(field)) {
-          return items.get(tableName)?.get(field)?.get(where[field])
+      if (indexedFieldNames[tableName]) {
+        if (indexedFieldNames[tableName].includes(field)) {
+          return items[tableName]?.[field]?.get(where[field])
         }
       }
     }
   }
 
   const updateItem = (tableName: string, item: any) => {
-    if (!items.has(tableName)) {
-      items.set(tableName, new Map())
+    if (!items[tableName]) {
+      items[tableName] = {}
     }
-    if (!indexedFieldNames.has(tableName)) {
+    if (!indexedFieldNames[tableName]) {
       throw new Error(`No indexed fields for table ${tableName}`)
     }
-    const tableItems = items.get(tableName)
-    for (const fieldName of indexedFieldNames.get(tableName)) {
-      if (!tableItems.has(fieldName)) {
-        tableItems.set(fieldName, new Map())
+    for (const fieldName of indexedFieldNames[tableName]) {
+      if (!items[tableName][fieldName]) {
+        items[tableName][fieldName] = new Map()
       }
-      const thisItems = tableItems.get(fieldName)
-      if (!thisItems.has(item[fieldName])) {
-        thisItems.set(item[fieldName], [item])
+      if (!items[tableName][fieldName].has(item[fieldName])) {
+        items[tableName][fieldName].set(item[fieldName], [item])
       } else {
-        const field = fields.get(tableName).get(fieldName)
+        const field = fields[tableName][fieldName]
         if (field && (field.isId || field.isUnique)) {
-          thisItems.set(item[fieldName], [item])
+          items[tableName][fieldName].set(item[fieldName], [item])
         } else {
-          const array = thisItems.get(item[fieldName])
+          const array = items[tableName][fieldName].get(item[fieldName])
           if (array.length === 0) {
             array.push(item)
           } else {
-            const thisIdFieldNames = idFieldNames.get(tableName) || []
+            const thisIdFieldNames = idFieldNames[tableName] || []
             let hasFound = false
             for (let i = 0; i < array.length; i++) {
               const oldItem = array[i]
@@ -102,9 +100,9 @@ export default function createIndexes() {
   }
 
   const deleteItemByField = (tableName: string, field: Prisma.DMMF.Field, item: any) => {
-    if (indexedFieldNames.has(tableName)) {
-      if (indexedFieldNames.get(tableName).includes(field.name)) {
-        items.get(tableName)?.get(field.name)?.delete(item[field.name])
+    if (indexedFieldNames[tableName]) {
+      if (indexedFieldNames[tableName].includes(field.name)) {
+        items[tableName]?.[field.name]?.delete(item[field.name])
       }
     }
   }


### PR DESCRIPTION
# Motivation
Calling `filter` & `map` on every item gets exponentially slower with a lot of items, especially when you have a lot of "joins".
We fix this by reference items by index (id's, relation fields, etc). The `filter` & `map` is still called, but on a subset of items.
This makes especially joins a lot faster.