### PR TITLE
Upgrade jest-mock-extended to version 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "@prisma/client": "^3.5.0 || ^4.7.0 || ^5.0.0"
   },
   "dependencies": {
-    "jest-mock-extended": "^2.0.4"
+    "jest-mock-extended": "^3.0.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,12 +1636,12 @@ jest-message-util@^27.5.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock-extended@^2.0.4:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-2.0.9.tgz#bc0e4a269cdb6047d7cc086e1d9722f7215ca795"
-  integrity sha512-eRZq7/FgwHbxOMm3Lo4DpQX6S2zi4OvwMVFHEb3FgDLp0Xy3P1WARkF93xxO5uD4nAHiEPYHZ25qVU9mAVxoLQ==
+jest-mock-extended@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-3.0.6.tgz#0105cd39d884080a561987e32755e862ee116ff5"
+  integrity sha512-DJuEoFzio0loqdX8NIwkbE9dgIXNzaj//pefOQxGkoivohpxbSQeNHCAiXkDNA/fmM4EIJDoZnSibP4w3dUJ9g==
   dependencies:
-    ts-essentials "^7.0.3"
+    ts-essentials "^9.4.2"
 
 jest-mock@^27.5.1:
   version "27.5.1"
@@ -2442,10 +2442,10 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
-ts-essentials@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
-  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
+ts-essentials@^9.4.2:
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-9.4.2.tgz#6d4bd23b46b61bf3e031816cc887e839eb62c33c"
+  integrity sha512-mB/cDhOvD7pg3YCLk2rOtejHjjdSi9in/IBYE13S+8WA5FBSraYf4V/ws55uvs0IvQ/l0wBOlXy5yBNZ9Bl8ZQ==
 
 ts-jest@^27.0.7:
   version "27.1.5"


### PR DESCRIPTION
We are making a storybook RSC dem using this awesome library to mock out the DB in the browser :)

https://github.com/storybookjs/module-mocking-demo

I bumped jest-mock-extended to make sure it is compatible with TS5:

```sh
 WARN  Issues with peer dependencies found
.
└─┬ prisma-mock 0.10.1
  └─┬ jest-mock-extended 2.0.9
    └── ✕ unmet peer typescript@"^3.0.0 || ^4.0.0": found 5.4.3

Done in 3.6s
```