### PR TITLE
fix: comparison with undefined value should be ignored

### DIFF
--- a/__tests__/where.test.ts
+++ b/__tests__/where.test.ts
@@ -588,4 +588,15 @@ Array [
       expect(users.length).toEqual(2)
     })
   })
+
+  test("lt & undefined", async () => {
+    const client = await createPrismaClient(data)
+    const users = await client.user.findMany({
+      where: {
+        // This condition should be ignored
+        id: { lt: undefined }
+      },
+    })
+    expect(users.length).toEqual(2)
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,10 @@ function IsFieldDefault(
   return (f as Prisma.DMMF.FieldDefault).name !== undefined
 }
 
+function isDefinedWithValue<T extends  object>(v: T, key: string): boolean {
+  return v[key] !== undefined
+}
+
 const throwKnownError = (message: string, { code = "P2025", meta }: { code?: string, meta?: any } = {}) => {
   const clientVersion = Prisma.prismaVersion.client
   // PrismaClientKnownRequestError prototype changed in version 4.7.0
@@ -805,16 +809,16 @@ const createPrismaMock = <P>(
           if ("contains" in matchFilter && match) {
             match = val.indexOf(matchFilter.contains) > -1
           }
-          if ("gt" in matchFilter && match) {
+          if (isDefinedWithValue(matchFilter, "gt") && match) {
             match = val > matchFilter.gt
           }
-          if ("gte" in matchFilter && match) {
+          if (isDefinedWithValue(matchFilter, "gte") && match) {
             match = val >= matchFilter.gte
           }
-          if ("lt" in matchFilter && match) {
+          if (isDefinedWithValue(matchFilter, "lt") && match) {
             match = val < matchFilter.lt
           }
-          if ("lte" in matchFilter && match) {
+          if (isDefinedWithValue(matchFilter, "lte") && match) {
             match = val <= matchFilter.lte
           }
           if ("in" in matchFilter && match) {


### PR DESCRIPTION
As I tested against `"@prisma/client": "5.14.0"`, it seemed to ignore undefined value in comparison, at least `lt`/`gt` series.

So, the real Prisma can work with the following function.
```typescript
async function findUpcomingMatches({
  start = new Date(),
  end,
}: {
  start?: Date;
  end?: Date | undefined;
}): Promise<Match[]> {
  return prisma.match.findMany({
    where: {
      start: {
        gte: start,
        lt: end, // no limits if the caller doesn't specify `end`.
      },
    },
    take: 3,
    orderBy: { start: 'asc' },
  });
}
```