### PR TITLE
Allow Prisma ^6 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:postgres": "env-cmd -e postgres jest --maxWorkers=1"
   },
   "peerDependencies": {
-    "@prisma/client": "^3.5.0 || ^4.7.0 || ^5.0.0"
+    "@prisma/client": "^3.5.0 || ^4.7.0 || ^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "jest-mock-extended": "^3.0.6"


### PR DESCRIPTION
Hi,
it seems the package.json needs to be updated to allow Prisma 6 clients, hopefully this solves it 👍🏻 