### PR TITLE
feat(delegate): improve default handling and unique constraints

### DIFF
--- a/__tests__/bugs.test.ts
+++ b/__tests__/bugs.test.ts
@@ -52,3 +52,26 @@ test("#22", async () => {
 
   expect(element).toMatchInlineSnapshot(`Array []`)
 })
+
+
+test("create returning null", async () => {
+
+  const prismaMock = await createPrismaClient()
+
+  const globalPlaylist = await prismaMock.stripe.create({
+    data: {
+      id: 1,
+      account: {
+        create: {
+          id: 1,
+          name: "Account"
+        }
+      },
+    }
+  })
+
+  expect(globalPlaylist).not.toBeNull()
+
+
+})
+

--- a/__tests__/include.test.ts
+++ b/__tests__/include.test.ts
@@ -88,6 +88,7 @@ test("findOne from", async () => {
   })
   expect(stripe).toEqual({
     ...data.stripe[0],
+    accountId: 1,
     active: false,
     sort: null,
     account: {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "preversion": "jest && tsc",
     "build": "tsc",
     "test": "jest",
+    "generate": "prisma generate",
     "watch": "tsc --watch",
     "test:postgres": "env-cmd -e postgres jest --maxWorkers=1"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ enum Role {
 model Account {
   id     Int     @id @default(autoincrement())
   users  User[]  @relation("AccountUsers")
-  stripe Stripe? @relation
+  stripe Stripe?
   name   String?
   guest  User[]  @relation("AccountGuest")
   sort   Int?
@@ -43,10 +43,12 @@ model User {
 model Stripe {
   id         Int     @id @default(autoincrement())
   customerId String  @unique
-  accountId  Int     @unique
+  accountId  Int
   account    Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
   active     Boolean @default(false)
   sort       Int?
+
+  @@unique([accountId])
 }
 
 model Answers {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,7 @@ const createPrismaMock = <P>(
       try {
         // @ts-ignore
         return await actions(client)
-      }
-      catch (error) {
+      } catch (error) {
         // Rollback data on error
         ref.data = snapshot
         throw error

--- a/src/utils/fieldHelpers.ts
+++ b/src/utils/fieldHelpers.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@prisma/client"
 import { Item } from "../types"
 
-export function IsFieldDefault(
+export function isFieldDefault(
   f:
     | Prisma.DMMF.FieldDefault
     | readonly Prisma.DMMF.FieldDefaultScalar[]
@@ -48,7 +48,9 @@ export const removeMultiFieldIds = (
 
   if (model.uniqueFields?.length > 0) {
     for (const uniqueField of model.uniqueFields) {
-      removeId(uniqueField)
+      if (uniqueField.length > 1) {
+        removeId(uniqueField)
+      }
     }
   }
   return data

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,6 +1660,13 @@ jest-message-util@^27.5.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock-extended@^3.0.6:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-3.0.7.tgz#3d902dabad99d7831bbe5fccee85ab0371c22675"
+  integrity sha512-7lsKdLFcW9B9l5NzZ66S/yTQ9k8rFtnwYdCNuRU/81fqDWicNDVhitTSPnrGmNeNm0xyw0JHexEOShrIKRCIRQ==
+  dependencies:
+    ts-essentials "^10.0.0"
+
 jest-mock@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.5.1.tgz#19948336d49ef4d9c52021d34ac7b5f36ff967d6"
@@ -2458,6 +2465,11 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+ts-essentials@^10.0.0:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-10.1.1.tgz#4e1d29b7c9b33c1a2744482376634c4fafba5210"
+  integrity sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==
 
 ts-jest@^27.0.7:
   version "27.1.5"


### PR DESCRIPTION
Refactor default value handling by renaming isFieldDefault for clarity.
Fix unique constraint logic to only consider ID fields when building where clauses.
Add support for composite unique indexes in the Stripe model schema.
Update dependencies to include ts-essentials and jest-mock-extended.
Add test case to verify create operation returns null correctly.
Clean up unused code and imports for better maintainability.