### PR TITLE
test: disable TypeScript checking in bugs.test.ts

### DIFF
--- a/__tests__/bugs.test.ts
+++ b/__tests__/bugs.test.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 
 import createPrismaClient from "./createPrismaClient"
 


### PR DESCRIPTION
Add a @ts-nocheck directive to the bugs.test.ts file to suppress
TypeScript errors during testing. This change helps avoid type
checking issues that interfere with test execution and improves
developer experience while working on bug-related tests.