### PR TITLE
feature/createManyAndReturn

### DIFF
--- a/__tests__/bulk-operations.test.ts
+++ b/__tests__/bulk-operations.test.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 import createPrismaClient from './createPrismaClient'
 
 describe("bulk-operations", () => {
@@ -99,6 +101,36 @@ Array [
     "role": "ADMIN",
     "sort": null,
     "uniqueField": "5",
+  },
+]
+`)
+  })
+
+
+  test("updateManyAndReturn", async () => {
+    const client = await createPrismaClient(data)
+    const users = await client.user.updateManyAndReturn({
+      where: {
+        clicks: {
+          gt: 4
+        },
+      },
+      data: {
+        name: 'Bard'
+      }
+    })
+    expect(users).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": null,
+    "age": 10,
+    "clicks": 5,
+    "deleted": false,
+    "id": 2,
+    "name": "Bard",
+    "role": "ADMIN",
+    "sort": null,
+    "uniqueField": "2",
   },
 ]
 `)

--- a/__tests__/bulk-operations.test.ts
+++ b/__tests__/bulk-operations.test.ts
@@ -66,4 +66,42 @@ describe("bulk-operations", () => {
 
     await client.$disconnect()
   })
+
+  test("createManyAndReturn", async () => {
+    const client = await createPrismaClient(data)
+    const users = await client.user.createManyAndReturn({
+      data: [
+        { name: 'Plaf', clicks: 4, uniqueField: '4' },
+        { name: 'Klof', clicks: 2, uniqueField: '5' },
+      ],
+    })
+    expect(users.length).toBe(2)
+    expect(users).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": null,
+    "age": 10,
+    "clicks": 4,
+    "deleted": false,
+    "id": 3,
+    "name": "Plaf",
+    "role": "ADMIN",
+    "sort": null,
+    "uniqueField": "4",
+  },
+  Object {
+    "accountId": null,
+    "age": 10,
+    "clicks": 2,
+    "deleted": false,
+    "id": 4,
+    "name": "Klof",
+    "role": "ADMIN",
+    "sort": null,
+    "uniqueField": "5",
+  },
+]
+`)
+  })
+
 })

--- a/__tests__/bulk-operations.test.ts
+++ b/__tests__/bulk-operations.test.ts
@@ -136,4 +136,38 @@ Array [
 `)
   })
 
+
+  test("updateManyAndReturn update where values", async () => {
+    const client = await createPrismaClient(data)
+    const users = await client.user.updateManyAndReturn({
+      where: {
+        clicks: {
+          gt: 3
+        },
+      },
+      data: {
+        name: 'Bard',
+        clicks: 2,
+      },
+    })
+    expect(users).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "accountId": null,
+    "age": 10,
+    "clicks": 2,
+    "deleted": false,
+    "id": 2,
+    "name": "Bard",
+    "role": "ADMIN",
+    "sort": null,
+    "uniqueField": "2",
+  },
+]
+`)
+  })
+
 })
+
+
+

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "lib/"
   ],
   "devDependencies": {
-    "@prisma/client": "5.13.0",
+    "@prisma/client": "6.11.1",
     "@types/jest": "^27.0.2",
     "cross-spawn": "^7.0.3",
     "env-cmd": "^10.1.0",
     "jest": "^27.3.1",
-    "prisma": "5.13.0",
+    "prisma": "6.11.1",
     "ts-jest": "^27.0.7",
     "typescript": "^4.4.4",
     "uuid": "^9.0.0"

--- a/src/delegate.ts
+++ b/src/delegate.ts
@@ -700,7 +700,8 @@ export const createDelegate = (
         [prop]: newItems,
       }
       ref.data = removeMultiFieldIds(model, ref.data)
-      return { data: ref.data, nbUpdated }
+      const data = findMany({ where: args.where })
+      return { data, nbUpdated }
     }
 
     /**
@@ -1236,6 +1237,10 @@ export const createDelegate = (
       updateMany: (args) => {
         const { nbUpdated } = updateMany(args)
         return { count: nbUpdated }
+      },
+      updateManyAndReturn: (args) => {
+        const { data, nbUpdated } = updateMany(args)
+        return data
       },
 
       /**

--- a/src/delegate.ts
+++ b/src/delegate.ts
@@ -1210,6 +1210,10 @@ export const createDelegate = (
         const createdItems = createMany(args)
         return { count: createdItems.length }
       },
+      createManyAndReturn: (args) => {
+        const createdItems = createMany(args)
+        return createdItems
+      },
       delete: (args) => {
         const item = findOne(args)
         if (!item) {

--- a/src/delegate.ts
+++ b/src/delegate.ts
@@ -13,7 +13,7 @@ import { shallowCompare } from "./utils/shallowCompare"
  */
 export const createDelegate = (
   ref: any, // Reference to the mock data store
-  datamodel: Prisma.DMMF.Datamodel, // Prisma datamodel definition
+  datamodel: Omit<Prisma.DMMF.Datamodel, 'indexes'>, // Prisma datamodel definition
   caseInsensitive: boolean, // Whether string comparisons should be case insensitive
   indexes: ReturnType<typeof createIndexes>, // Index management for performance
 ) => {

--- a/src/utils/fieldHelpers.ts
+++ b/src/utils/fieldHelpers.ts
@@ -56,7 +56,7 @@ export const removeMultiFieldIds = (
   return data
 }
 
-export const createGetFieldRelationshipWhere = (datamodel: Prisma.DMMF.Datamodel, manyToManyData: { [relationName: string]: Array<{ [type: string]: Item }> }) =>
+export const createGetFieldRelationshipWhere = (datamodel: Omit<Prisma.DMMF.Datamodel, 'indexes'>, manyToManyData: { [relationName: string]: Array<{ [type: string]: Item }> }) =>
   (item: any, field: Prisma.DMMF.Field, model: Prisma.DMMF.Model) => {
     if (field.relationFromFields.length === 0) {
       const joinmodel = datamodel.models.find((model) => {

--- a/src/utils/getWhereOnIds.ts
+++ b/src/utils/getWhereOnIds.ts
@@ -1,0 +1,22 @@
+import { Prisma } from "@prisma/client";
+
+
+export default function getWhereOnIds(model: Prisma.DMMF.Model, item: any) {
+  let where = {}
+  const fields = model.primaryKey?.fields
+  if (!fields || fields.length === 0) {
+    for (const field of model.fields) {
+      if (field.isId) {
+        where[field.name] = item[field.name]
+      }
+    }
+  } else if (fields.length > 1) {
+    for (const field of fields) {
+      where[field] = item[field]
+    }
+    where = {
+      [fields.join("_")]: where
+    }
+  }
+  return where
+}

--- a/src/utils/queryMatching.ts
+++ b/src/utils/queryMatching.ts
@@ -10,7 +10,7 @@ type Props = {
   getFieldRelationshipWhere: ReturnType<typeof createGetFieldRelationshipWhere>
   Delegate: any
   model: Prisma.DMMF.Model
-  datamodel: Prisma.DMMF.Datamodel
+  datamodel: Omit<Prisma.DMMF.Datamodel, 'indexes'>
   caseInsensitive: boolean
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,46 +515,53 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@prisma/client@5.13.0":
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.13.0.tgz#b9f1d0983d714e982675201d8222a9ecb4bdad4a"
-  integrity sha512-uYdfpPncbZ/syJyiYBwGZS8Gt1PTNoErNYMuqHDa2r30rNSFtgTA/LXsSk55R7pdRTMi5pHkeP9B14K6nHmwkg==
+"@prisma/client@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-6.11.1.tgz#ef97454d8b0bb192b26ec4111def83ddee4615e3"
+  integrity sha512-5CLFh8QP6KxRm83pJ84jaVCeSVPQr8k0L2SEtOJHwdkS57/VQDcI/wQpGmdyOZi+D9gdNabdo8tj1Uk+w+upsQ==
 
-"@prisma/debug@5.13.0":
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.13.0.tgz#d88b0f6fafa0c216e20e284ed9fc30f1cbe45786"
-  integrity sha512-699iqlEvzyCj9ETrXhs8o8wQc/eVW+FigSsHpiskSFydhjVuwTJEfj/nIYqTaWFYuxiWQRfm3r01meuW97SZaQ==
-
-"@prisma/engines-version@5.13.0-23.b9a39a7ee606c28e3455d0fd60e78c3ba82b1a2b":
-  version "5.13.0-23.b9a39a7ee606c28e3455d0fd60e78c3ba82b1a2b"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.13.0-23.b9a39a7ee606c28e3455d0fd60e78c3ba82b1a2b.tgz#a72a4fb83ba1fd01ad45f795aa55168f60d34723"
-  integrity sha512-AyUuhahTINGn8auyqYdmxsN+qn0mw3eg+uhkp8zwknXYIqoT3bChG4RqNY/nfDkPvzWAPBa9mrDyBeOnWSgO6A==
-
-"@prisma/engines@5.13.0":
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.13.0.tgz#8994ebf7b4e35aee7746a8465ec22738379bcab6"
-  integrity sha512-hIFLm4H1boj6CBZx55P4xKby9jgDTeDG0Jj3iXtwaaHmlD5JmiDkZhh8+DYWkTGchu+rRF36AVROLnk0oaqhHw==
+"@prisma/config@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@prisma/config/-/config-6.11.1.tgz#c0a952d5d30b009fef390371fd359e7b4d55d956"
+  integrity sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==
   dependencies:
-    "@prisma/debug" "5.13.0"
-    "@prisma/engines-version" "5.13.0-23.b9a39a7ee606c28e3455d0fd60e78c3ba82b1a2b"
-    "@prisma/fetch-engine" "5.13.0"
-    "@prisma/get-platform" "5.13.0"
+    jiti "2.4.2"
 
-"@prisma/fetch-engine@5.13.0":
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.13.0.tgz#9b6945c7b38bb59e840f8905b20ea7a3d059ca55"
-  integrity sha512-Yh4W+t6YKyqgcSEB3odBXt7QyVSm0OQlBSldQF2SNXtmOgMX8D7PF/fvH6E6qBCpjB/yeJLy/FfwfFijoHI6sA==
-  dependencies:
-    "@prisma/debug" "5.13.0"
-    "@prisma/engines-version" "5.13.0-23.b9a39a7ee606c28e3455d0fd60e78c3ba82b1a2b"
-    "@prisma/get-platform" "5.13.0"
+"@prisma/debug@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-6.11.1.tgz#88e912b8a265445d207cc0ce1823fe69cd689a05"
+  integrity sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==
 
-"@prisma/get-platform@5.13.0":
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.13.0.tgz#99ef909a52b9d79b64d72d2d3d8210c4892b6572"
-  integrity sha512-B/WrQwYTzwr7qCLifQzYOmQhZcFmIFhR81xC45gweInSUn2hTEbfKUPd2keAog+y5WI5xLAFNJ3wkXplvSVkSw==
+"@prisma/engines-version@6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9":
+  version "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9.tgz#a242978dc1cb09024fc738a40962c70bb81b6b33"
+  integrity sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==
+
+"@prisma/engines@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-6.11.1.tgz#6e8cdc2a90017ceeb8a6b7c3eb6ac397fe794726"
+  integrity sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==
   dependencies:
-    "@prisma/debug" "5.13.0"
+    "@prisma/debug" "6.11.1"
+    "@prisma/engines-version" "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9"
+    "@prisma/fetch-engine" "6.11.1"
+    "@prisma/get-platform" "6.11.1"
+
+"@prisma/fetch-engine@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-6.11.1.tgz#796fa38a420f18bd5df6b06eaff77b0f44da80e9"
+  integrity sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==
+  dependencies:
+    "@prisma/debug" "6.11.1"
+    "@prisma/engines-version" "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9"
+    "@prisma/get-platform" "6.11.1"
+
+"@prisma/get-platform@6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-6.11.1.tgz#5543da490916b05fdaf880933c6cf29d15b26961"
+  integrity sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==
+  dependencies:
+    "@prisma/debug" "6.11.1"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
@@ -1856,6 +1863,11 @@ jest@^27.3.1:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
+jiti@2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.4.2.tgz#d19b7732ebb6116b06e2038da74a55366faef560"
+  integrity sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2173,12 +2185,13 @@ pretty-format@^27.0.0, pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-prisma@5.13.0:
-  version "5.13.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.13.0.tgz#1f06e20ccfb6038ad68869e6eacd3b346f9d0851"
-  integrity sha512-kGtcJaElNRAdAGsCNykFSZ7dBKpL14Cbs+VaQ8cECxQlRPDjBlMHNFYeYt0SKovAVy2Y65JXQwB3A5+zIQwnTg==
+prisma@6.11.1:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-6.11.1.tgz#496fde4da3a9fc79ecc95f6a615c3a9025b37e17"
+  integrity sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==
   dependencies:
-    "@prisma/engines" "5.13.0"
+    "@prisma/config" "6.11.1"
+    "@prisma/engines" "6.11.1"
 
 prompts@^2.0.1:
   version "2.4.2"


### PR DESCRIPTION
- Updated Prisma dependencies to version 6.11.1 and adjusted datamodel type to omit 'indexes' where needed.
- Added createManyAndReturn methods to the user delegate with corresponding tests.
- Introduced updateManyAndReturn method to bulk-operations for updating multiple records and returning the updated data.
- Added getWhereOnIds utility to support composite keys in where clauses, improving updateMany and related delegate logic.
- Included tests to verify correct behavior of createManyAndReturn and updateManyAndReturn methods, including composite key scenarios.