### PR TITLE
ci: update publish workflow to run on ubuntu-24.04

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,11 +18,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   publish:
     name: Publish npm packages
-    runs-on: [self-hosted, trueconf]
-    permissions:
-      contents: write
-      pull-requests: write
-      packages: write
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Change the publish job runner from a self-hosted environment to
ubuntu-24.04. Remove explicit permissions settings to simplify the
workflow. This update improves consistency and leverages a standard
CI environment for publishing npm packages.