### PR TITLE
fix(release): push tags after publishing release

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "tsc",
     "test": "jest",
     "generate": "prisma generate",
-    "release": "yarn build && changeset publish",
+    "release": "yarn build && changeset publish && git push --follow-tags",
     "watch": "tsc --watch",
     "test:postgres": "env-cmd -e postgres jest --maxWorkers=1",
     "changeset": "changeset",


### PR DESCRIPTION
Update the release script to push commits and tags to the remote
repository after publishing. This ensures that tags created during
the release process are properly pushed and available remotely.