### PR TITLE
chore(config): remove restricted access from changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,6 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
Remove the "access": "restricted" setting from the changeset
configuration to allow broader access. This change simplifies the
configuration and aligns with updated project access policies.