### PR TITLE
chore(config): set changeset access to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
Add "access": "public" to the changeset config to ensure that
published packages are publicly accessible. This change aligns
with the intended visibility settings and prevents accidental
private publishing.