### PR TITLE
test: fix indexes

### DIFF
--- a/.changeset/khaki-wombats-swim.md
+++ b/.changeset/khaki-wombats-swim.md
@@ -1,0 +1,5 @@
+---
+"prisma-mock": minor
+---
+
+Add indexes to increate performance (configurable with enableIndexes)

--- a/__tests__/createPrismaClient.ts
+++ b/__tests__/createPrismaClient.ts
@@ -30,7 +30,7 @@ export default async function createPrismaClient(data?: any, options?: any) {
   const isReal = process.env.PROVIDER === "postgresql"
 
   let client = isReal ? new PrismaClient() : createPrismaMock<PrismaClient>({}, undefined, undefined, {
-    enableIndexes: false,
+    enableIndexes: true,
     ...options,
   })
 

--- a/__tests__/performance.test.ts
+++ b/__tests__/performance.test.ts
@@ -1,8 +1,10 @@
 import createPrismaClient from "./createPrismaClient"
 
 
-test.skip("performance test", async () => {
-  const client = await createPrismaClient()
+test("performance test", async () => {
+  const client = await createPrismaClient(undefined, {
+    enableIndexes: true,
+  })
   performance.mark("start-create")
   for (let i = 0; i < 50; i++) {
     await client.user.create({

--- a/src/indexes.ts
+++ b/src/indexes.ts
@@ -179,6 +179,7 @@ export default function createIndexes(isEnabled: boolean = true) {
         // Create new index entry
         items[tableName][fieldName].set(item[fieldName], [item])
       } else {
+
         const field = fields[tableName][fieldName]
         const array = items[tableName][fieldName].get(item[fieldName])
 
@@ -190,7 +191,8 @@ export default function createIndexes(isEnabled: boolean = true) {
           if (array.length === 0) {
             array.push(item)
           } else {
-            const thisIdFieldNames = idFieldNames[tableName] || []
+            // Filter out this field 
+            const thisIdFieldNames = (idFieldNames[tableName] || []).filter(f => f !== fieldName)
             let hasFound = false
 
             // Try to find and update existing item by ID


### PR DESCRIPTION
Enable indexes by default in the Prisma mock client to improve query
performance and accuracy in tests. Update index update logic to exclude
the current field from ID field filtering, preventing incorrect item
overwrites. Also, activate the previously skipped performance test to
validate these changes.