### PR TITLE
feat(tests+query): every-in-where test and fix 'every' logic

### DIFF
--- a/.changeset/modern-planets-fail.md
+++ b/.changeset/modern-planets-fail.md
@@ -1,0 +1,5 @@
+---
+"prisma-mock": patch
+---
+
+Fix an issue where every did not work correctly

--- a/__tests__/bugs.test.ts
+++ b/__tests__/bugs.test.ts
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-
 import createPrismaClient from "./createPrismaClient"
 
 test("#22", async () => {
@@ -9,21 +8,21 @@ test("#22", async () => {
   // Create a page and user
   const user1 = await prismaMock.user.create({
     data: {
-      uniqueField: "1"
+      uniqueField: "1",
     },
   })
 
   // Create a second page and user
   const user2 = await prismaMock.user.create({
     data: {
-      uniqueField: "2"
+      uniqueField: "2",
     },
   })
 
   // Create a third page and user
   await prismaMock.user.create({
     data: {
-      uniqueField: "3"
+      uniqueField: "3",
     },
   })
 
@@ -55,9 +54,7 @@ test("#22", async () => {
   expect(element).toMatchInlineSnapshot(`Array []`)
 })
 
-
 test("create returning null", async () => {
-
   const prismaMock = await createPrismaClient()
 
   const globalPlaylist = await prismaMock.stripe.create({
@@ -66,14 +63,68 @@ test("create returning null", async () => {
       account: {
         create: {
           id: 1,
-          name: "Account"
-        }
+          name: "Account",
+        },
       },
-    }
+    },
   })
 
   expect(globalPlaylist).not.toBeNull()
-
-
 })
 
+test("every in where", async () => {
+  const prismaMock = await createPrismaClient()
+  await prismaMock.user.create({
+    data: {
+      name: "John",
+      uniqueField: "1",
+      posts: {
+        create: [
+          { id: 1, title: "A" },
+          { id: 2, title: "B" },
+        ],
+      },
+    },
+  })
+  await prismaMock.user.create({
+    data: {
+      name: "Pieter",
+      uniqueField: "2",
+      posts: { create: [{ id: 3, title: "B" }] },
+    },
+  })
+  await prismaMock.user.create({
+    data: {
+      name: "Sjors",
+      uniqueField: "3",
+      posts: { create: [{ id: 4, title: "C" }] },
+    },
+  })
+  const users = await prismaMock.user.findMany({
+    where: {
+      posts: {
+        every: {
+          id: {
+            in: [3, 2],
+          },
+        },
+      },
+    },
+  })
+  expect(users).toHaveLength(1)
+  expect(users).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "accountId": null,
+        "age": 10,
+        "clicks": null,
+        "deleted": false,
+        "id": 2,
+        "name": "Pieter",
+        "role": "ADMIN",
+        "sort": null,
+        "uniqueField": "2",
+      },
+    ]
+  `)
+})


### PR DESCRIPTION
Add new integration test "every in where" to validate querying with
posts.every conditions and ensure correct mock behavior. Clean up minor
formatting in existing tests.

Refactor createMatch and Delegate wiring to pass a getDelegateForFieldName
helper instead of a generic Delegate parameter. Use that helper to
resolve related model delegates by field name. Fix the "every" handling:
treat an empty set of related records as vacuously true (return true
when all.length === 0) and ensure findMany uses the delegate for
correct comparisons.

These changes fix incorrect evaluation of every filters on relations
and make delegate resolution explicit and safer for nested queries.